### PR TITLE
MEAクラスをimmutable (データの変更はできない)とする

### DIFF
--- a/pyMEA/__init__.py
+++ b/pyMEA/__init__.py
@@ -7,11 +7,13 @@ from pyMEA.find_peaks.peak_detection import (
 )
 from pyMEA.read.CardioAveWave import CardioAveWave
 from pyMEA.read.FilterMEA import FilterMEA
-from pyMEA.read.model import MEA
+from pyMEA.read.model.MEA import MEA
+from pyMEA.read.model.MutableMEA import MutableMEA
 from pyMEA.utils.old_ver_gradient.fit_gradient import calc_gradient_velocity
 
 __all__ = [
     "MEA",
+    "MutableMEA",
     "FigMEA",
     "Calculator",
     "FilterMEA",

--- a/pyMEA/__init__.py
+++ b/pyMEA/__init__.py
@@ -7,7 +7,7 @@ from pyMEA.find_peaks.peak_detection import (
 )
 from pyMEA.read.CardioAveWave import CardioAveWave
 from pyMEA.read.FilterMEA import FilterMEA
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model import MEA
 from pyMEA.utils.old_ver_gradient.fit_gradient import calc_gradient_velocity
 
 __all__ = [

--- a/pyMEA/calculator/FPD.py
+++ b/pyMEA/calculator/FPD.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 from numpy import array_equal, ndarray
 
 from pyMEA.find_peaks.peak_model import NegPeaks, PosPeaks
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model.MEA import MEA
 
 
 @dataclass(frozen=True)

--- a/pyMEA/calculator/calculator.py
+++ b/pyMEA/calculator/calculator.py
@@ -8,7 +8,7 @@ from pyMEA.calculator.FPD import FPD
 from pyMEA.find_peaks.peak_detection import detect_peak_pos
 from pyMEA.find_peaks.peak_model import NegPeaks64, Peaks64, PosPeaks
 from pyMEA.gradient.Gradients import Gradients
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model.MEA import MEA
 from pyMEA.utils.decorators import ch_validator
 
 

--- a/pyMEA/figure/FigMEA.py
+++ b/pyMEA/figure/FigMEA.py
@@ -7,7 +7,7 @@ from pyMEA.figure.plot.plot import showDetection
 from pyMEA.figure.plot.raster_plot import raster_plot
 from pyMEA.find_peaks.peak_model import Peaks64
 from pyMEA.gradient.Gradients import Gradients
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model.MEA import MEA
 from pyMEA.utils.decorators import channel
 
 

--- a/pyMEA/figure/plot/histogram.py
+++ b/pyMEA/figure/plot/histogram.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy import ndarray
 
 from pyMEA.find_peaks.peak_model import Peaks64
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model.MEA import MEA
 
 
 def peak_flatten(MEA_data: MEA, peak_index: Peaks64, eles: list[int]) -> ndarray:

--- a/pyMEA/figure/plot/plot.py
+++ b/pyMEA/figure/plot/plot.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from numpy import ndarray
 
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model.MEA import MEA
 
 circuit_eles = [
     1,

--- a/pyMEA/figure/plot/raster_plot.py
+++ b/pyMEA/figure/plot/raster_plot.py
@@ -2,7 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from pyMEA.find_peaks.peak_model import Peaks64
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model.MEA import MEA
 
 
 def raster_plot(

--- a/pyMEA/find_peaks/peak_detection.py
+++ b/pyMEA/find_peaks/peak_detection.py
@@ -12,7 +12,7 @@ from pyMEA.find_peaks.peak_model import (
     PosPeaks,
     PosPeaks64,
 )
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model.MEA import MEA
 
 
 # 64電極すべての下ピークを取得

--- a/pyMEA/gradient/Gradients.py
+++ b/pyMEA/gradient/Gradients.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from pyMEA.gradient.Gradient import Gradient
 from pyMEA.gradient.Solver import Solver
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model.MEA import MEA
 
 
 class Gradients:

--- a/pyMEA/read/CardioAveWave.py
+++ b/pyMEA/read/CardioAveWave.py
@@ -1,27 +1,23 @@
 import numpy as np
+from black.cache import dataclass
 
 from pyMEA.find_peaks.peak_detection import detect_peak_neg
 from pyMEA.find_peaks.peak_model import NegPeaks64
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model.MEA import MEA
 
 
+@dataclass(frozen=True)
 class CardioAveWave(MEA):
-    def __init__(
-        self,
-        hed_path: str,
-        start: int = 0,
-        end: int = 120,
-        front=0.05,
-        back=0.3,
-        distance=3000,
-    ) -> None:
-        super().__init__(hed_path, start, end)
-        neg_peaks = detect_peak_neg(self, distance)
-        self._array = calc_64_ave_waves(self, neg_peaks, front, back)
+    front: float = 0.05
+    back: float = 0.3
+    distance: int = 3000
 
-        self._start = 0
-        self._end = front + back
-        self._time = self.end - self.start
+    def __post_init__(self):
+        super().__post_init__()
+        neg_peaks = detect_peak_neg(self, self.distance)
+        object.__setattr__(
+            self, "array", calc_64_ave_waves(self, neg_peaks, self.front, self.back)
+        )
 
 
 """

--- a/pyMEA/read/FilterMEA.py
+++ b/pyMEA/read/FilterMEA.py
@@ -1,21 +1,19 @@
 import numpy as np
 
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model.MEA import MEA
 
 
 class FilterMEA(MEA):
-    def __init__(
-        self,
-        hed_path: str,
-        start: int = 0,
-        end: int = 120,
-        power_noise_freq=50,
-        steps=10,
-    ) -> None:
-        super().__init__(hed_path, start, end)
-        self.power_noise_freq = power_noise_freq
-        self.steps = steps
-        self._array = filter_by_moving_average(self, power_noise_freq, steps)
+    power_noise_freq: int = 50
+    steps: int = 10
+
+    def __post_init__(self):
+        super().__post_init__()
+        object.__setattr__(
+            self,
+            "array",
+            filter_by_moving_average(self, self.power_noise_freq, self.steps),
+        )
 
 
 """

--- a/pyMEA/read/MutableMEA.py
+++ b/pyMEA/read/MutableMEA.py
@@ -5,7 +5,7 @@ from pyMEA.read.read_bio import decode_hed, hed2array
 from pyMEA.utils.decorators import time_validator
 
 
-class MEA:
+class MutableMEA:
     @time_validator
     def __init__(self, hed_path: str, start: int = 0, end: int = 120) -> None:
         """

--- a/pyMEA/read/model/BioPath.py
+++ b/pyMEA/read/model/BioPath.py
@@ -1,14 +1,13 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(frozen=True)
 class BioPath:
-    path: str = field(init=False)
+    path: str
 
-    def __init__(self, bio_path: str):
-        if not bio_path.endswith(".bio"):
+    def __post_init__(self):
+        if not self.path.endswith(".bio"):
             raise ValueError(".bioファイルのパスを入力してください")
-        self.path = bio_path
 
     def __repr__(self) -> str:
         return self.path

--- a/pyMEA/read/model/HedPath.py
+++ b/pyMEA/read/model/HedPath.py
@@ -1,14 +1,13 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(frozen=True)
 class HedPath:
-    path: str = field(init=False)
+    path: str  # init=True がデフォルトなので明示しなくてOK
 
-    def __init__(self, hed_path: str):
-        if not hed_path.endswith(".hed"):
+    def __post_init__(self):
+        if not self.path.endswith(".hed"):
             raise ValueError(".hedファイルのパスを入力してください")
-        self.path = hed_path
 
     def __repr__(self) -> str:
         return self.path

--- a/pyMEA/read/model/MEA.py
+++ b/pyMEA/read/model/MEA.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass, field
+from typing import Any
+
+from numpy import dtype, ndarray
+
+from pyMEA.read.model.HedPath import HedPath
+from pyMEA.read.read_bio import decode_hed, hed2array
+
+
+@dataclass(frozen=True)
+class MEA:
+    hed_path: str
+    start: int
+    end: int
+    SAMPLING_RATE: int = field(init=False)
+    GAIN: int = field(init=False)
+    array: ndarray[Any, dtype] = field(init=False)
+
+    def __post_init__(self):
+        hed_path = HedPath(self.hed_path)
+        SAMPLING_RATE, GAIN = decode_hed(hed_path)
+        array = hed2array(hed_path, self.start, self.end)
+        object.__setattr__(self, "SAMPLING_RATE", SAMPLING_RATE)
+        object.__setattr__(self, "GAIN", GAIN)
+
+        # object.__setattr__ を使って frozen dataclass の内部を書き換える
+        object.__setattr__(self, "array", self._freeze_array(array))
+
+    @staticmethod
+    def _freeze_array(arr: ndarray[Any]) -> ndarray[Any]:
+        arr.setflags(write=False)
+        return arr
+
+    @property
+    def time(self):
+        return self.end - self.start
+
+    def __repr__(self):
+        return repr(self.array)
+
+    def __getitem__(self, index: int) -> ndarray:
+        return self.array[index]
+
+    def __len__(self) -> int:
+        return len(self.array)
+
+    def __add__(self, value):
+        return self.array + value
+
+    def __sub__(self, value):
+        return self.array - value
+
+    def __mul__(self, value):
+        return self.array * value
+
+    def __truediv__(self, value):
+        return self.array / value
+
+    def __floordiv__(self, value):
+        return self.array // value
+
+    @property
+    def info(self) -> str:
+        info = (
+            f"読み込み開始時間  : {self.start} s\n"
+            f"読み込み終了時間  : {self.end} s\n"
+            f"読み込み合計時間  : {self.time} s\n"
+            f"サンプリングレート: {self.SAMPLING_RATE} Hz\n"
+            f"GAIN           : {self.GAIN}"
+        )
+        print(info)
+        return info
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return self.array.shape

--- a/pyMEA/read/model/MutableMEA.py
+++ b/pyMEA/read/model/MutableMEA.py
@@ -14,12 +14,12 @@ class MutableMEA:
             start: 読み込み開始時間 [s]
             end: 読み込み終了時間[s]
         """
-        self._hed_path: HedPath = HedPath(hed_path)
-        self._start: int = start
-        self._end: int = end
-        self._time: int = end - start
-        self._SAMPLING_RATE, self._GAIN = decode_hed(self._hed_path)
-        self._array = hed2array(self._hed_path, self._start, self._end)
+        self.hed_path: HedPath = HedPath(hed_path)
+        self.start: int = start
+        self.end: int = end
+        self.time: int = end - start
+        self.SAMPLING_RATE, self.GAIN = decode_hed(self.hed_path)
+        self.array = hed2array(self.hed_path, self.start, self.end)
 
     def __repr__(self):
         return repr(self.array)
@@ -34,16 +34,16 @@ class MutableMEA:
         return self.array + value
 
     def __sub__(self, value):
-        return self._array - value
+        return self.array - value
 
     def __mul__(self, value):
-        return self._array * value
+        return self.array * value
 
     def __truediv__(self, value):
-        return self._array / value
+        return self.array / value
 
     def __floordiv__(self, value):
-        return self._array // value
+        return self.array // value
 
     @property
     def info(self) -> str:
@@ -60,31 +60,3 @@ class MutableMEA:
     @property
     def shape(self) -> tuple[int, ...]:
         return self.array.shape
-
-    @property
-    def hed_path(self) -> HedPath:
-        return self._hed_path
-
-    @property
-    def start(self) -> int:
-        return self._start
-
-    @property
-    def end(self) -> int:
-        return self._end
-
-    @property
-    def time(self) -> int:
-        return self._time
-
-    @property
-    def SAMPLING_RATE(self) -> int:
-        return self._SAMPLING_RATE
-
-    @property
-    def GAIN(self) -> int:
-        return self._GAIN
-
-    @property
-    def array(self):
-        return self._array

--- a/pyMEA/read/read_bio.py
+++ b/pyMEA/read/read_bio.py
@@ -6,6 +6,7 @@ from numpy import ndarray
 
 from pyMEA.read.model.BioPath import BioPath
 from pyMEA.read.model.HedPath import HedPath
+from pyMEA.utils.decorators import time_validator
 
 
 # hedファイルの解読関数
@@ -72,6 +73,7 @@ def read_bio(
 
 
 # hedファイルの情報からbioファイルを一気に読み込む
+@time_validator
 def hed2array(hed_path: HedPath, start: int, end: int) -> ndarray:
     """
     ヘッダーファイルからサンプリングレートとGainを読み取りbioファイルを読み込む\n

--- a/pyMEA/utils/old_ver_gradient/fit_gradient.py
+++ b/pyMEA/utils/old_ver_gradient/fit_gradient.py
@@ -7,7 +7,7 @@ from numpy import ndarray
 from scipy.optimize import curve_fit
 
 from pyMEA.find_peaks.peak_model import Peaks64
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model.MEA import MEA
 
 
 def remove_undetected_ch(

--- a/pyMEA/utils/params.py
+++ b/pyMEA/utils/params.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy import dtype, floating, ndarray
 
 from pyMEA.find_peaks.peak_detection import detect_peak_pos
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model.MEA import MEA
 
 
 # バゼット (Bazett's)とFredericia (フレデリシア)の補正式で補正しFredericia (たものも計算)で補正しFredericia (たものも計算)で補正したものも計算

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def parse_requirements(filename):
 
 setup(
     name="pyMEA",  # パッケージ名（pip listで表示される）
-    version="3.0.0",  # バージョン
+    version="3.1.0",  # バージョン
     description="MEA計測データを読み込み・解析するためのモジュール",  # 説明
     author="kentaro kito",  # 作者名
     packages=find_packages(exclude=["test", "test.*"]),

--- a/test/src/integration/integration_test_CardioAveWave.py
+++ b/test/src/integration/integration_test_CardioAveWave.py
@@ -10,8 +10,8 @@ start, end = 0, 5
 front, back = 0.05, 0.3
 data = CardioAveWave(path.__str__(), start, end, front, back)
 cal = Calculator(data, 450)
-neg_peak_index = detect_peak_neg(data.array)
-pos_peak_index = detect_peak_pos(data.array, height=(0, 500))
+neg_peak_index = detect_peak_neg(data)
+pos_peak_index = detect_peak_pos(data, height=(0, 500))
 fm = FigMEA(data)
 
 

--- a/test/src/integration/integration_test_FilterMEA.py
+++ b/test/src/integration/integration_test_FilterMEA.py
@@ -8,8 +8,8 @@ path = get_resource_path("230615_day2_test_5s_.hed")
 
 start, end = 1, 2
 data = FilterMEA(path.__str__(), start, end)
-neg_peak_index = detect_peak_neg(data.array)
-pos_peak_index = detect_peak_pos(data.array, height=(0, 500))
+neg_peak_index = detect_peak_neg(data)
+pos_peak_index = detect_peak_pos(data, height=(0, 500))
 fm = FigMEA(data)
 
 

--- a/test/src/integration/integration_test_MEA.py
+++ b/test/src/integration/integration_test_MEA.py
@@ -3,7 +3,7 @@ from test.utils import get_resource_path
 from pyMEA import Calculator, detect_peak_all
 from pyMEA.figure.FigMEA import FigMEA
 from pyMEA.find_peaks.peak_detection import detect_peak_neg, detect_peak_pos
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model.MEA import MEA
 
 path = get_resource_path("230615_day2_test_5s_.hed")
 

--- a/test/src/unit/calculator/test_calculator.py
+++ b/test/src/unit/calculator/test_calculator.py
@@ -6,14 +6,14 @@ import numpy as np
 from pyMEA import detect_peak_neg
 from pyMEA.calculator.calculator import Calculator
 from pyMEA.figure.FigMEA import FigMEA
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model.MEA import MEA
 
 
 class CalculatorTest(unittest.TestCase):
     def setUp(self):
         self.path = get_resource_path("230615_day2_test_5s_.hed")
         self.data = MEA(self.path.__str__(), 0, 5)
-        self.peak_index = detect_peak_neg(self.data.array)
+        self.peak_index = detect_peak_neg(self.data)
         self.calc450 = Calculator(self.data, 450)
         self.calc150 = Calculator(self.data, 150)
         self.fm = FigMEA(self.data)

--- a/test/src/unit/figure/test_figure.py
+++ b/test/src/unit/figure/test_figure.py
@@ -6,14 +6,14 @@ import numpy as np
 
 from pyMEA.figure.FigMEA import FigMEA
 from pyMEA.find_peaks.peak_detection import detect_peak_neg
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model.MEA import MEA
 
 
 class MyTestCase(unittest.TestCase):
     def setUp(self):
         self.path = get_resource_path("230615_day2_test_5s_.hed")
         self.data = MEA(self.path.__str__(), 0, 5)
-        self.peak_index = detect_peak_neg(self.data.array)
+        self.peak_index = detect_peak_neg(self.data)
         self.fm = FigMEA(self.data)
 
     @patch("matplotlib.pyplot.show")

--- a/test/src/unit/find_peaks/test_peak_detection.py
+++ b/test/src/unit/find_peaks/test_peak_detection.py
@@ -1,15 +1,16 @@
 import unittest
 from test.utils import get_resource_path
 
-from pyMEA import MEA, detect_peak_all, detect_peak_neg
+from pyMEA import detect_peak_all, detect_peak_neg
 from pyMEA.find_peaks.peak_detection import detect_peak_pos
+from pyMEA.read.model.MEA import MEA
 
 
 class MyTestCase(unittest.TestCase):
     def setUp(self):
         self.path = get_resource_path("230615_day2_test_5s_.hed")
         self.data = MEA(self.path.__str__(), 0, 5)
-        self.neg_peak_index = detect_peak_neg(self.data.array)
+        self.neg_peak_index = detect_peak_neg(self.data)
         self.pos_peak_index = detect_peak_pos(self.data, height=(200, 50000))
         self.all_peak_index = detect_peak_all(self.data)
 

--- a/test/src/unit/gradient/test_Gradients.py
+++ b/test/src/unit/gradient/test_Gradients.py
@@ -3,7 +3,7 @@ from test.utils import get_resource_path
 
 from pyMEA import detect_peak_neg
 from pyMEA.gradient.Gradients import Gradients
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model.MEA import MEA
 
 
 class MyTestCase(unittest.TestCase):

--- a/test/src/unit/read/test_MEA.py
+++ b/test/src/unit/read/test_MEA.py
@@ -3,7 +3,7 @@ from test.utils import get_resource_path
 
 import numpy as np
 
-from pyMEA.read.MEA import MEA
+from pyMEA.read.model.MEA import MEA
 
 
 class MEATest(unittest.TestCase):
@@ -58,7 +58,7 @@ GAIN           : {data.GAIN}""",
 
     def test_hedファイル以外のファイルパスを入力する場合_例外発生する(self):
         with self.assertRaises(ValueError) as context:
-            MEA("/User/your/mea_data.bio")
+            MEA("/User/your/mea_data.bio", 0, 5)
         self.assertEqual(".hedファイルのパスを入力してください", str(context.exception))
 
 


### PR DESCRIPTION
# MEAクラスのデータは参照しかできないようにした
データ書き換え可能だと処理の中で意図せず計測データを書き換えてしまい正しく解析できなくなるのでデータはread-onlyとする。
```python
data = MEA(hed_path, 0, 5)

# 2-3 sにのノイズがあったので除去する -> エラーになる
data[5][2 * data.SAMPLING_RATE : 3 * data.SAMPLING_RATE] = 0
```
このような計測データを書き換えるような処理をすると次のエラーになる
```
ValueError: assignment destination is read-only
```

## ノイズ処理の検討等で書き換えたい場合
#### 以下のどちらかの方法を使用
1. 測定データのコピーを変数に代入
```python
# 測定データのコピーを変数に持っておく
tmp_data = data.array.copy() # .copy()をつけないと参照を代入することになる

# これはOK
tmp_data[5][2 * data.SAMPLING_RATE : 3 * data.SAMPLING_RATE] = 0
```
2. MutableMEAクラスを使用して計測データを読み込む
```
# このデータは自由に書き換え可能 (本番のデータ解析ではなるべく使わない)
data = MutableMEA(hed_path, 0, 5)
```