### PR TITLE
波形描画の配色を自由に変えられるように修正

### DIFF
--- a/README_ja.md
+++ b/README_ja.md
@@ -189,6 +189,7 @@ def showAll(
         volt_max=200,   # 最小電位 (μV)
         figsize=(8, 8), # グラフの縦横比
         dpi=300,        # 解像度
+        color: list[str] | list[list[float]] = None, # 波形の配色
         isBuf=False,    # グラフ画像のインスタンスを返すかどうか (Falseでグラフをjupyter上に表示)
     ) -> FigImage | None:
 ```
@@ -213,6 +214,7 @@ def showSingle(
     dpi=None,
     xlabel="Time (s)",
     ylabel="Voltage (μV)",
+    color: str | None=None,
     isBuf=False,
 ) -> FigImage | None:
 ```
@@ -236,6 +238,8 @@ def plotPeaks(
     dpi=None,
     xlabel="Time (s)",
     ylabel="Voltage (μV)",
+    color: str | None=None,
+    peak_color: list[str] | list[list[float]] = None,
     isBuf=False
 ) -> FigImage | None:
 ```
@@ -263,6 +267,7 @@ def showDetection(
     xlabel="Time (s)",
     ylabel="Electrode Number",
     dpi=300,
+    color: list[str] | list[list[float]] = None,
     isBuf=False,
 ) -> FigImage | None:
 ```

--- a/pyMEA/figure/plot/plot.py
+++ b/pyMEA/figure/plot/plot.py
@@ -114,9 +114,12 @@ def showDetection(
     figsize=(12, 12),
     xlabel="Time (s)",
     ylabel="Electrode Number",
+    color=None,
     dpi=300,
     isBuf=False,
 ):
+    if color is None:
+        color = [[0, 118, 178]]
     MEA_data = []
     for ele in eles:
         MEA_data.append(MEA_raw[ele])
@@ -126,9 +129,24 @@ def showDetection(
     end_frame = int(end * sampling_rate)
 
     plt.figure(figsize=figsize, dpi=dpi)
+    color_index = 0
     for i, index in enumerate(np.array(data)):
         tmp_volt = (index - np.mean(index)) / adjust_wave
-        plt.plot(MEA_raw[0][start_frame:end_frame], tmp_volt[start_frame:end_frame] + i)
+        if color is None:
+            plt.plot(
+                MEA_raw[0][start_frame:end_frame],
+                tmp_volt[start_frame:end_frame] + i,
+            )
+        else:
+            plt.plot(
+                MEA_raw[0][start_frame:end_frame],
+                tmp_volt[start_frame:end_frame] + i,
+                color=color[color_index],
+            )
+
+            color_index += 1
+            if color_index >= len(color):
+                color_index = 0
 
     if isDisplayCh:
         # 電極番号をY軸の目盛りにする

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def parse_requirements(filename):
 
 setup(
     name="pyMEA",  # パッケージ名（pip listで表示される）
-    version="3.6.0",  # バージョン
+    version="3.6.1",  # バージョン
     description="MEA計測データを読み込み・解析するためのモジュール",  # 説明
     author="kentaro kito",  # 作者名
     packages=find_packages(exclude=["test", "test.*"]),


### PR DESCRIPTION
mtaplotlibの[配色指定方式](https://pythondatascience.plavox.info/matplotlib/%E8%89%B2%E3%81%AE%E5%90%8D%E5%89%8D)全てに対応
- 文字列指定
- 1文字表記指定
- 16進数カラーコード指定
- RGB指定