### PR TITLE
feat: devcontainerのVS Code拡張機能とruff設定を追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,16 +12,30 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-"postCreateCommand": "pip3 install --user -r requirements.txt",
+"postCreateCommand": "pip3 install --user -r requirements.txt && pip3 install --user -e .",
 "customizations": {
 	"vscode": {
 		"extensions": [
 			"donjayamanne.python-extension-pack",
+			"charliermarsh.ruff",
 			"ionutvmi.path-autocomplete",
 			"ms-toolsai.jupyter",
+			"ms-toolsai.jupyter-keymap",
+			"ms-toolsai.jupyter-renderers",
+			"ms-toolsai.vscode-jupyter-cell-tags",
+			"ms-toolsai.vscode-jupyter-slideshow",
 			"streetsidesoftware.code-spell-checker",
 			"ms-python.black-formatter"
-		]
+		],
+		"settings": {
+			"ruff.lint.exclude": ["**/*.ipynb"],
+			"python.analysis.ignore": ["**/*.ipynb"],
+			"[jupyter-notebook]": {
+				"editor.formatOnSave": false,
+				"editor.codeActionsOnSave": {},
+				"editor.defaultFormatter": null
+			}
+		}
 	}
 }
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,1 @@
+extend-exclude = ["*.ipynb"]


### PR DESCRIPTION
## Summary

- Jupyter関連拡張機能を4つ追加 (`jupyter-keymap`, `jupyter-renderers`, `vscode-jupyter-cell-tags`, `vscode-jupyter-slideshow`)
- `charliermarsh.ruff` を追加（`.py`ファイルのリント用）
- `.ipynb`ファイルでは警告が出ないよう設定
  - `ruff.toml` で `extend-exclude = ["*.ipynb"]` を追加
  - `python.analysis.ignore` でPylanceの診断も無効化
- `postCreateCommand` に `pip install -e .` を追加

## Test plan

- [ ] devcontainerをリビルドして拡張機能が正しくインストールされることを確認
- [ ] `.py` ファイルでruffのリントが動作することを確認
- [ ] `.ipynb` ファイルで警告・波線が表示されないことを確認