### PR TITLE
refactor: Phase 3 - 責務分割と重複解消

### DIFF
--- a/pyMEA/application/MutableMEA.py
+++ b/pyMEA/application/MutableMEA.py
@@ -18,7 +18,9 @@ class MutableMEA:
         self.start: int = start
         self.end: int = end
         self.time: int = end - start
-        self.SAMPLING_RATE, self.GAIN = decode_hed(self.hed_path)
+        hed_data = decode_hed(self.hed_path)
+        self.SAMPLING_RATE = hed_data.SAMPLING_RATE
+        self.GAIN = hed_data.GAIN
         self.array = hed2array(self.hed_path, self.start, self.end)
 
     def __repr__(self):

--- a/pyMEA/application/PyMEA.py
+++ b/pyMEA/application/PyMEA.py
@@ -43,51 +43,34 @@ class PyMEA:
     def __floordiv__(self, value):
         return self.data.array // value
 
+    def _rebuild(self, new_data: MEA) -> "PyMEA":
+        """変換後のMEAデータから各責務クラスを再構築したPyMEAを返す"""
+        return PyMEA(
+            new_data,
+            self.electrode,
+            FigMEA(new_data, self.electrode),
+            Calculator(new_data, self.electrode.ele_dis),
+        )
+
     def from_slice(self, start: int | float, end: int | float):
         start_frame, end_frame = (
             int((start - self.data.start) * self.data.SAMPLING_RATE),
             int((end - self.data.start) * self.data.SAMPLING_RATE),
         )
-        new_data = self.data.from_slice(start_frame, end_frame)
-        return PyMEA(
-            new_data,
-            self.electrode,
-            FigMEA(new_data, self.electrode),
-            Calculator(new_data, self.electrode.ele_dis),
-        )
+        return self._rebuild(self.data.from_slice(start_frame, end_frame))
 
     def from_beat_cycles(
         self, peak_index: Peaks64, base_ch: int, margin_time: float = 0.25
     ):
         new_data_list = self.data.from_beat_cycles(peak_index, base_ch, margin_time)
-        return [
-            PyMEA(
-                new_data,
-                self.electrode,
-                FigMEA(new_data, self.electrode),
-                Calculator(new_data, self.electrode.ele_dis),
-            )
-            for new_data in new_data_list
-        ]
+        return [self._rebuild(new_data) for new_data in new_data_list]
 
     def init_time(self):
         """時刻データを0 (s)からにしたMEAインスタンスを返却"""
-        new_data = self.data.init_time()
-        return PyMEA(
-            new_data,
-            self.electrode,
-            FigMEA(new_data, self.electrode),
-            Calculator(new_data, self.electrode.ele_dis),
-        )
+        return self._rebuild(self.data.init_time())
 
     def down_sampling(self, down_sampling_rate=100):
-        new_data = self.data.down_sampling(down_sampling_rate)
-        return PyMEA(
-            new_data,
-            self.electrode,
-            FigMEA(new_data, self.electrode),
-            Calculator(new_data, self.electrode.ele_dis),
-        )
+        return self._rebuild(self.data.down_sampling(down_sampling_rate))
 
     def iirnotch_filter(self, filter_hz=50, Q=30):
         """
@@ -105,10 +88,4 @@ class PyMEA:
         filtered : PyMEA
             フィルタ後の信号
         """
-        new_data = self.data.iirnotch_filter(filter_hz, Q)
-        return PyMEA(
-            new_data,
-            self.electrode,
-            FigMEA(new_data, self.electrode),
-            Calculator(new_data, self.electrode.ele_dis),
-        )
+        return self._rebuild(self.data.iirnotch_filter(filter_hz, Q))

--- a/pyMEA/domain/model/Electrode.py
+++ b/pyMEA/domain/model/Electrode.py
@@ -5,7 +5,31 @@ import numpy as np
 from numpy import float64
 from numpy._typing import NDArray
 
+from pyMEA.constants import ELECTRODE_GRID_SIZE
 from pyMEA.domain.validators import ch_validator
+
+
+def get_mesh(
+    ele_dis: int, mesh_num: int
+) -> tuple[NDArray[float64], NDArray[float64]]:
+    """
+    電極エリアを mesh_num x mesh_num に分割したグリッド配列を取得する
+    """
+    # データ範囲を取得
+    x_min, x_max = 0, ele_dis * (ELECTRODE_GRID_SIZE - 1)
+    y_min, y_max = 0, ele_dis * (ELECTRODE_GRID_SIZE - 1)
+
+    # 取得したデータ範囲で新しく座標にする配列を作成
+    x_coord = np.linspace(x_min, x_max, mesh_num)
+    y_coord = np.linspace(y_min, y_max, mesh_num)
+
+    # 取得したデータ範囲で新しく座標にする配列を作成
+    xx, yy = np.meshgrid(x_coord, y_coord)
+
+    # 電極番号順に配列を修正
+    yy = np.rot90(np.rot90(yy))
+
+    return xx, yy
 
 
 @dataclass(frozen=True)
@@ -17,21 +41,7 @@ class Electrode:
         """
         電極のグリッド配列 (8 x 8)を取得するメソッド
         """
-        # データ範囲を取得
-        x_min, x_max = 0, self.ele_dis * 7
-        y_min, y_max = 0, self.ele_dis * 7
-
-        # 取得したデータ範囲で新しく座標にする配列を作成
-        x_coord = np.linspace(x_min, x_max, 8)
-        y_coord = np.linspace(y_min, y_max, 8)
-
-        # 取得したデータ範囲で新しく座標にする配列を作成
-        xx, yy = np.meshgrid(x_coord, y_coord)
-
-        # 電極番号順に配列を修正
-        yy = np.rot90(np.rot90(yy))
-
-        return xx, yy
+        return get_mesh(self.ele_dis, ELECTRODE_GRID_SIZE)
 
     @ch_validator
     def get_coordinate(self, ch: int) -> tuple[NDArray[float64], NDArray[float64]]:
@@ -46,6 +56,6 @@ class Electrode:
 
         """
         mesh = self.get_electrode_mesh
-        x = mesh[0][(ch - 1) // 8][(ch - 1) % 8]
-        y = mesh[1][(ch - 1) // 8][(ch - 1) % 8]
+        x = mesh[0][(ch - 1) // ELECTRODE_GRID_SIZE][(ch - 1) % ELECTRODE_GRID_SIZE]
+        y = mesh[1][(ch - 1) // ELECTRODE_GRID_SIZE][(ch - 1) % ELECTRODE_GRID_SIZE]
         return x, y

--- a/pyMEA/domain/service/gradient/Gradients.py
+++ b/pyMEA/domain/service/gradient/Gradients.py
@@ -1,17 +1,16 @@
-import statistics
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-import numpy as np
 from numpy import float64
 from numpy._typing import NDArray
 
-from pyMEA.constants import DEFAULT_ELECTRODE_DISTANCE, NUM_ELECTRODES
+from pyMEA.constants import DEFAULT_ELECTRODE_DISTANCE
 from pyMEA.domain.model.MEA import MEA
 from pyMEA.domain.model.peak_model import Peaks64
 from pyMEA.domain.service.gradient.Gradient import Gradient
 from pyMEA.domain.service.gradient.Solver import Solver
+from pyMEA.domain.service.peak_times import remove_undetected_ch_from64ch
 
 if TYPE_CHECKING:
     from pyMEA.presentation.FigImage import FigImage
@@ -86,28 +85,3 @@ class Gradients:
         ]
         if isBuf:
             return buf_list
-
-
-def remove_undetected_ch_from64ch(
-    data: MEA, peak_index: Peaks64
-) -> tuple[list[list[np.ndarray[Any, Any]]], list[int]]:
-    # ピークの時刻 (s)を取得
-    time = [data[0][peak_index[i]] for i in range(1, NUM_ELECTRODES + 1)]
-
-    # 各電極の取得ピーク数の最頻値以外の電極は削除
-    peaks = [len(peak_index[i]) for i in range(1, NUM_ELECTRODES + 1)]
-    remove_ch = []
-    for i in range(len(time)):
-        if len(time[i]) != statistics.mode(peaks):
-            remove_ch.append(i)
-
-    # ピークを正しく検出できていないchのデータを削除
-    for ch in sorted(remove_ch, reverse=True):
-        time.pop(ch)
-    print("弾いた電極番号: ", np.array(remove_ch))
-
-    times = []
-    for j in range(len(time[0])):
-        times.append([time[i][j] for i in range(len(time))])
-
-    return times, remove_ch

--- a/pyMEA/domain/service/gradient/Solver.py
+++ b/pyMEA/domain/service/gradient/Solver.py
@@ -7,6 +7,9 @@ from numpy import float64
 from numpy._typing import NDArray
 from scipy.optimize import curve_fit
 
+from pyMEA.constants import ELECTRODE_GRID_SIZE
+from pyMEA.domain.model.Electrode import get_mesh
+
 
 @dataclass(frozen=True)
 class Solver:
@@ -56,7 +59,7 @@ class Solver:
             popt: モデル式の係数が入ったリスト
             r2: 決定係数
         """
-        xx, yy = get_mesh(self.ele_dis, 8)
+        xx, yy = get_mesh(self.ele_dis, ELECTRODE_GRID_SIZE)
         xx = np.delete(xx, self.remove_ch)
         yy = np.delete(yy, self.remove_ch)
 
@@ -68,27 +71,6 @@ class Solver:
         r2 = 1 - (rss / tss)
 
         return np.array(popt), r2
-
-
-def get_mesh(ele_dis: int, mesh_num: int) -> tuple[NDArray[float64], NDArray[float64]]:
-    """
-    グリッド配列を取得するメソッド
-    """
-    # データ範囲を取得
-    x_min, x_max = 0, ele_dis * 7
-    y_min, y_max = 0, ele_dis * 7
-
-    # 取得したデータ範囲で新しく座標にする配列を作成
-    x_coord = np.linspace(x_min, x_max, mesh_num)
-    y_coord = np.linspace(y_min, y_max, mesh_num)
-
-    # 取得したデータ範囲で新しく座標にする配列を作成
-    xx, yy = np.meshgrid(x_coord, y_coord)
-
-    # 電極番号順に配列を修正
-    yy = np.rot90(np.rot90(yy))
-
-    return xx, yy
 
 
 def model(

--- a/pyMEA/domain/service/peak_detection.py
+++ b/pyMEA/domain/service/peak_detection.py
@@ -14,6 +14,42 @@ from pyMEA.domain.model.peak_model import (
 from pyMEA.domain.model.MEA import MEA
 
 
+def _detect_peaks_by_ch(
+    MEA_data: MEA,
+    is_positive: bool,
+    distance,
+    threshold,
+    min_amp,
+    prominence,
+    width,
+) -> dict[int, ndarray]:
+    """全電極に対して片側 (上または下) のピーク検出を行う共通処理"""
+    peak_dict: dict[int, ndarray] = {}
+    for i in range(1, len(MEA_data)):
+        # ピーク抽出の閾値を設定
+        height = np.std(MEA_data[i]) * threshold
+        # 閾値が最低閾値を下回っていた場合は最低閾値の値を閾値の値に設定する
+        if height < min_amp:
+            height = min_amp
+
+        data = MEA_data.array[i].copy()
+        if is_positive:
+            data[data < 0] = 0
+        else:
+            data[data > 0] = 0
+            data = -data
+        detect_peak_index, _ = find_peaks(
+            data,
+            height=height,
+            distance=distance,
+            prominence=prominence,
+            width=width,
+        )
+        peak_dict[i] = detect_peak_index
+
+    return peak_dict
+
+
 # 64電極すべての下ピークを取得
 def detect_peak_neg(
     MEA_data: MEA,
@@ -34,26 +70,16 @@ def detect_peak_neg(
         prominence: 突起度
         width: ピークの幅
     """
-    peak_dict: dict[int, NegPeaks] = {}
-    for i in range(1, len(MEA_data)):
-        # ピーク抽出の閾値を設定
-        height = np.std(MEA_data[i]) * threshold
-        # 閾値が最低閾値を下回っていた場合は最低閾値の値を閾値の値に設定する
-        if height < min_amp:
-            height = min_amp
-
-        data = MEA_data.array[i].copy()
-        data[data > 0] = 0
-        detect_peak_index, _ = find_peaks(
-            -data,
-            height=height,
-            distance=distance,
-            prominence=prominence,
-            width=width,
-        )
-        peak_dict[i] = NegPeaks(detect_peak_index)
-
-    return NegPeaks64(peak_dict)
+    peak_dict = _detect_peaks_by_ch(
+        MEA_data,
+        is_positive=False,
+        distance=distance,
+        threshold=threshold,
+        min_amp=min_amp,
+        prominence=prominence,
+        width=width,
+    )
+    return NegPeaks64({ch: NegPeaks(peaks) for ch, peaks in peak_dict.items()})
 
 
 # 64電極すべての上ピークを取得
@@ -76,26 +102,16 @@ def detect_peak_pos(
         prominence: 突起度
         width: ピークの幅
     """
-    peak_dict: dict[int, PosPeaks] = {}
-    for i in range(1, len(MEA_data)):
-        # ピーク抽出の閾値を設定
-        height = np.std(MEA_data[i]) * threshold
-        # 閾値が最低閾値を下回っていた場合は最低閾値の値を閾値の値に設定する
-        if height < min_amp:
-            height = min_amp
-
-        data = MEA_data.array[i].copy()
-        data[data < 0] = 0
-        detect_peak_index, _ = find_peaks(
-            data,
-            height=height,
-            distance=distance,
-            prominence=prominence,
-            width=width,
-        )
-        peak_dict[i] = PosPeaks(detect_peak_index)
-
-    return PosPeaks64(peak_dict)
+    peak_dict = _detect_peaks_by_ch(
+        MEA_data,
+        is_positive=True,
+        distance=distance,
+        threshold=threshold,
+        min_amp=min_amp,
+        prominence=prominence,
+        width=width,
+    )
+    return PosPeaks64({ch: PosPeaks(peaks) for ch, peaks in peak_dict.items()})
 
 
 def detect_cardio_second_peak(

--- a/pyMEA/domain/service/peak_times.py
+++ b/pyMEA/domain/service/peak_times.py
@@ -1,0 +1,52 @@
+"""ピーク時刻行列の生成と、ピーク未検出電極の除去。
+
+各電極のピーク検出数の最頻値と異なる電極 (ピークを正しく検出できていない電極)
+を除外し、拍動周期ごとのピーク時刻行列を返す。
+"""
+
+import statistics
+
+import numpy as np
+
+from pyMEA.constants import NUM_ELECTRODES
+from pyMEA.domain.model.MEA import MEA
+from pyMEA.domain.model.peak_model import Peaks64
+
+
+def remove_undetected_ch(
+    data: MEA, peak_index: Peaks64, chs: list[int]
+) -> tuple[np.ndarray, list[int]]:
+    """
+    指定電極のうちピーク未検出の電極を除去したピーク時刻行列を返す
+
+    Returns:
+        times: 拍動周期ごとのピーク時刻行列 (s)
+        remove_ch_index: 除去した電極のchsにおけるインデックス
+    """
+    # ピークの時刻 (s)を取得
+    time = [data[0][peak_index[ch]] for ch in chs]
+
+    # 各電極の取得ピーク数の最頻値以外の電極は削除
+    peaks = [len(peak_index[ch]) for ch in chs]
+    mode_peaks = statistics.mode(peaks)
+    remove_ch_index = [i for i in range(len(time)) if len(time[i]) != mode_peaks]
+
+    # ピークを正しく検出できていないchのデータを削除
+    for ch in sorted(remove_ch_index, reverse=True):
+        time.pop(ch)
+    print("弾いた電極番号: ", np.array(remove_ch_index))
+
+    times = np.array(
+        [[time[i][j] for i in range(len(time))] for j in range(len(time[0]))]
+    )
+
+    return times, remove_ch_index
+
+
+def remove_undetected_ch_from64ch(
+    data: MEA, peak_index: Peaks64
+) -> tuple[np.ndarray, list[int]]:
+    """
+    全64電極のうちピーク未検出の電極を除去したピーク時刻行列を返す
+    """
+    return remove_undetected_ch(data, peak_index, list(range(1, NUM_ELECTRODES + 1)))

--- a/pyMEA/presentation/FigMEA.py
+++ b/pyMEA/presentation/FigMEA.py
@@ -1,66 +1,30 @@
-import io
 from dataclasses import dataclass
 
-import matplotlib.pyplot as plt
 import numpy as np
-from scipy.signal import welch
 
-from pyMEA.constants import ELECTRODE_GRID_SIZE
 from pyMEA.domain.model.Electrode import Electrode
-from pyMEA.presentation.plot.histogram import mkHist
-from pyMEA.presentation.plot.plot import (
-    draw_line,
-    draw_line_conduction,
-    remove_undetected_ch,
-    showDetection,
-)
-from pyMEA.presentation.plot.raster_plot import raster_plot
-from pyMEA.presentation.video import FigImage, VideoMEA
-from pyMEA.domain.service.peak_detection import detect_peak_neg
+from pyMEA.domain.model.MEA import MEA
 from pyMEA.domain.model.peak_model import Peaks64
 from pyMEA.domain.service.gradient.Gradient import Gradient
-from pyMEA.domain.service.gradient.Gradients import Gradients, remove_undetected_ch_from64ch
-from pyMEA.domain.service.gradient.Solver import Solver
-from pyMEA.domain.model.MEA import MEA
-from pyMEA.presentation.output import channel, output_buf
+from pyMEA.domain.service.gradient.Gradients import Gradients
+from pyMEA.presentation.FigImage import FigImage
+from pyMEA.presentation.plot import colormap, waveform
+from pyMEA.presentation.plot.color import normalize_color
+from pyMEA.presentation.plot.histogram import mkHist
+from pyMEA.presentation.plot.plot import showDetection
+from pyMEA.presentation.plot.raster_plot import raster_plot
+from pyMEA.presentation.video import VideoMEA
 
 
 @dataclass(frozen=True)
 class FigMEA:
+    """グラフ描画のファサード。
+
+    各メソッドの実装本体は presentation/plot/ 配下の小モジュールにある。
+    """
+
     data: MEA
     electrode: Electrode
-
-    @channel
-    @output_buf
-    def plot_spectrum(
-        self, ch: int, max_freq=500, nperseg=2048, figsize=(10, 4), dpi=100, isBuf=False
-    ):
-        """
-        与えられた信号のスペクトルをプロットする関数
-        - FFTの振幅スペクトル
-        """
-        N = len(self.data[ch])
-
-        # === FFT ===
-        fft_vals = np.fft.rfft(self.data[ch])
-        fft_freq = np.fft.rfftfreq(N, 1 / self.data.SAMPLING_RATE)
-        amplitude = np.abs(fft_vals) / N
-
-        # === Welch ===
-        f, Pxx = welch(self.data[ch], fs=self.data.SAMPLING_RATE, nperseg=nperseg)
-
-        # === プロット ===
-        plt.figure(figsize=figsize, dpi=dpi)
-
-        # FFT
-        plt.plot(fft_freq, amplitude)
-        plt.xlim(0, max_freq)
-        plt.xticks(np.arange(0, max_freq + 50, 50))
-        plt.xlabel("Frequency [Hz]")
-        plt.ylabel("Amplitude")
-        plt.grid()
-
-        plt.tight_layout()
 
     def _set_times(self, start, end) -> tuple[int, int]:
         # 時間の設定がなければ読み込み時間全体をプロットするようにする。
@@ -71,7 +35,23 @@ class FigMEA:
 
         return start, end
 
-    @output_buf
+    def plot_spectrum(
+        self, ch: int, max_freq=500, nperseg=2048, figsize=(10, 4), dpi=100, isBuf=False
+    ):
+        """
+        与えられた信号のスペクトルをプロットする関数
+        - FFTの振幅スペクトル
+        """
+        return waveform.plot_spectrum(
+            self.data,
+            ch,
+            max_freq=max_freq,
+            nperseg=nperseg,
+            figsize=figsize,
+            dpi=dpi,
+            isBuf=isBuf,
+        )
+
     def showAll(
         self,
         start=None,
@@ -96,42 +76,18 @@ class FigMEA:
             color: プロットの配色
             isBuf: グラフ画像を返すかどうか
         """
-        # 時間の設定がない場合はデータの最初から5秒間をプロットする。
-        if start is None:
-            start = self.data.start
-        if end is None:
-            end = start + 5
-
-        # 読み込み開始時間が0ではないときズレが生じるため差を取っている
-        start_frame = int(abs(self.data.start - start) * self.data.SAMPLING_RATE)
-        end_frame = int(abs(self.data.start - end) * self.data.SAMPLING_RATE)
-
-        x = self.data.array[0][start_frame:end_frame]
-
-        color = self._normalize_color(color)
-
-        fig, axes = plt.subplots(
-            ELECTRODE_GRID_SIZE, ELECTRODE_GRID_SIZE, figsize=figsize, dpi=dpi
+        return waveform.show_all(
+            self.data,
+            start=start,
+            end=end,
+            volt_min=volt_min,
+            volt_max=volt_max,
+            figsize=figsize,
+            dpi=dpi,
+            color=color,
+            isBuf=isBuf,
         )
-        color_index = 0
-        for i, ax in enumerate(axes.flat):
-            if color is None:
-                # 配色指定あり
-                ax.plot(x, self.data.array[i + 1][start_frame:end_frame])
-            else:
-                # 配色指定なし
-                ax.plot(
-                    x,
-                    self.data.array[i + 1][start_frame:end_frame],
-                    color=color[color_index],
-                )
-                color_index += 1
-                if color_index >= len(color):
-                    color_index = 0
-            ax.set_ylim(volt_min, volt_max)
 
-    @channel
-    @output_buf
     def showSingle(
         self,
         ch: int,
@@ -163,24 +119,21 @@ class FigMEA:
             isBuf: グラフ画像を返すかどうか
         """
         start, end = self._set_times(start, end)
-
-        # 読み込み開始時間が0ではないときズレが生じるため差を取っている
-        start_frame = int(abs(self.data.start - start) * self.data.SAMPLING_RATE)
-        end_frame = int(abs(self.data.start - end) * self.data.SAMPLING_RATE)
-
-        plt.figure(figsize=figsize, dpi=dpi)
-        plt.plot(
-            self.data.array[0][start_frame:end_frame],
-            self.data.array[ch][start_frame:end_frame],
+        return waveform.show_single(
+            self.data,
+            ch,
+            start,
+            end,
+            volt_min=volt_min,
+            volt_max=volt_max,
+            figsize=figsize,
+            dpi=dpi,
+            xlabel=xlabel,
+            ylabel=ylabel,
             color=color,
+            isBuf=isBuf,
         )
-        plt.xlim(start, end)
-        plt.ylim(volt_min, volt_max)
-        plt.xlabel(xlabel)
-        plt.ylabel(ylabel)
 
-    @channel
-    @output_buf
     def plotPeaks(
         self,
         ch: int,
@@ -195,14 +148,14 @@ class FigMEA:
         ylabel="Voltage (μV)",
         color: str = None,
         peak_color: list[str] | list[list[float]] = None,
-        isBuf=False
+        isBuf=False,
     ) -> FigImage | None:
         """
         1電極の波形とピークの位置をプロット
 
         Args:
             ch: 描画する電極番号
-            *peak_index: ピーク配列 (可変長)以降の引数は引数名を指定する
+            *peak_indexes: ピーク配列 (可変長)以降の引数は引数名を指定する
             start: 読み込み開始時間 [s]
             end: 読み込み終了時間[s]
             volt_min: マイナス電位 [μV]
@@ -216,36 +169,22 @@ class FigMEA:
             isBuf: グラフ画像を返すかどうか
         """
         start, end = self._set_times(start, end)
-
-        # 読み込み開始時間が0ではないときズレが生じるため差を取っている
-        start_frame = int(abs(self.data.start - start) * self.data.SAMPLING_RATE)
-        end_frame = int(abs(self.data.start - end) * self.data.SAMPLING_RATE)
-
-        # 波形データのプロット
-        plt.figure(figsize=figsize, dpi=dpi)
-        x, y = (
-            self.data.array[0][start_frame:end_frame],
-            self.data.array[ch][start_frame:end_frame],
+        return waveform.plot_peaks(
+            self.data,
+            ch,
+            *peak_indexes,
+            start=start,
+            end=end,
+            volt_min=volt_min,
+            volt_max=volt_max,
+            figsize=figsize,
+            dpi=dpi,
+            xlabel=xlabel,
+            ylabel=ylabel,
+            color=color,
+            peak_color=peak_color,
+            isBuf=isBuf,
         )
-        plt.plot(x, y, color=color)
-
-        # ピークのプロット
-        peak_color = self._normalize_color(peak_color, "red")
-        peak_color_index = 0
-        for peak_index in peak_indexes:
-            peaks = peak_index[ch]
-            peaks = peaks[start_frame < peaks]
-            peaks = peaks[peaks < end_frame]
-            plt.plot(x[peaks], y[peaks], ".", color=peak_color[peak_color_index])
-
-            peak_color_index += 1
-            if peak_color_index >= len(peak_color):
-                peak_color_index = 0
-
-        plt.xlim(start, end)
-        plt.ylim(volt_min, volt_max)
-        plt.xlabel(xlabel)
-        plt.ylabel(ylabel)
 
     def showDetection(
         self,
@@ -293,7 +232,7 @@ class FigMEA:
             xlabel=xlabel,
             ylabel=ylabel,
             dpi=dpi,
-            color=self._normalize_color(color, None),
+            color=normalize_color(color, None),
             isBuf=isBuf,
         )
         return buf
@@ -372,37 +311,18 @@ class FigMEA:
             cmap: カラーセット
             isBuf: グラフ画像を返すかどうか
         """
-        if base_ch:
-            # 基準電極が指定されていたらその電極の拍動周期ごとにピーク抽出する
-            result = []
-            for divided_data in self.data.from_beat_cycles(peak_index, base_ch):
-                peak = detect_peak_neg(divided_data)
-                times, remove_ch = remove_undetected_ch_from64ch(self.data, peak)
-                grad = Gradient(
-                    Solver(times[0], remove_ch, self.electrode.ele_dis, mesh_num)
-                )
-                buf: io.BytesIO = grad.draw2d(
-                    contour, isQuiver, dpi=dpi, cmap=cmap, isBuf=isBuf
-                )
-
-                if isBuf:
-                    result.append(buf)
-                else:
-                    result.append(grad)
-            if isBuf:
-                # list[BytesIO]を渡してもlist[FigImage]にキャストされる
-                return VideoMEA(result)
-            else:
-                return result
-
-        else:
-            grads = Gradients(self.data, peak_index, self.electrode.ele_dis, mesh_num)
-            buf_list = grads.draw_2d(contour, isQuiver, dpi=dpi, cmap=cmap, isBuf=isBuf)
-
-            if isBuf:
-                return VideoMEA(buf_list)
-            else:
-                return grads.gradients
+        return colormap.draw_2d(
+            self.data,
+            self.electrode,
+            peak_index,
+            base_ch=base_ch,
+            mesh_num=mesh_num,
+            contour=contour,
+            isQuiver=isQuiver,
+            dpi=dpi,
+            cmap=cmap,
+            isBuf=isBuf,
+        )
 
     def draw_3d(
         self,
@@ -425,13 +345,17 @@ class FigMEA:
             dpi: 解像度
             isBuf: グラフ画像を返すかどうか
         """
-        grads = Gradients(self.data, peak_index, self.electrode.ele_dis, mesh_num)
-        buf_list = grads.draw_3d(xlabel, ylabel, clabel, dpi, isBuf=isBuf)
-
-        if isBuf:
-            return VideoMEA(buf_list)
-        else:
-            return grads
+        return colormap.draw_3d(
+            self.data,
+            self.electrode,
+            peak_index,
+            mesh_num=mesh_num,
+            xlabel=xlabel,
+            ylabel=ylabel,
+            clabel=clabel,
+            dpi=dpi,
+            isBuf=isBuf,
+        )
 
     def draw_line_conduction(
         self,
@@ -448,7 +372,7 @@ class FigMEA:
         ----------
         Parameters
             peak_index: ピーク抽出結果
-            chs: AMCの電極番号配列
+            amc_chs: AMCの電極番号配列
             base_ch: 基準電極
             isLoop: 経路が環状かどうか
             dpi: 解像度
@@ -457,59 +381,13 @@ class FigMEA:
         -------
 
         """
-        if base_ch:
-            # 基準電極が指定されていたらその電極の拍動周期ごとにピーク抽出する
-            if base_ch not in amc_chs:
-                raise ValueError("基準電極はAMC内の電極から選択してください")
-
-            result = []
-            for divided_data in self.data.from_beat_cycles(peak_index, base_ch):
-                peak = detect_peak_neg(divided_data)
-                times, remove_ch_index = remove_undetected_ch(
-                    divided_data, peak, amc_chs
-                )
-                result.append(
-                    draw_line(
-                        times[0],
-                        amc_chs,
-                        remove_ch_index,
-                        self.electrode,
-                        isLoop,
-                        dpi,
-                        isBuf=isBuf,
-                    )
-                )
-            if isBuf:
-                return VideoMEA(result)
-        else:
-            buf_list = draw_line_conduction(
-                self.data, self.electrode, peak_index, amc_chs, isLoop, dpi, isBuf=isBuf
-            )
-
-            if isBuf:
-                return VideoMEA(buf_list)
-
-    def _normalize_color(self, color, default_color=None):
-        """
-        peak_color を標準化して常に list[list[float] または str] のリストにする
-
-        Args:
-            color: str | list[str] | list[float] | list[list[float]] | None
-
-        Returns:
-            list[str] | list[list[float]]: 正規化された色リスト
-        """
-        if color is None:
-            # デフォルトカラー
-            return [default_color]
-        elif isinstance(color, str):
-            return [color]
-        elif isinstance(color, list):
-            # RGB値1セットだけ渡された場合 [0.1, 0.2, 0.3]
-            if all(isinstance(c, (int, float)) for c in color):
-                return [color]
-            # list[str] や list[list[float]] はそのまま
-            return color
-
-        else:
-            raise TypeError("peak_color must be str or list[str] or list[list[float]]")
+        return colormap.draw_line_conduction_map(
+            self.data,
+            self.electrode,
+            peak_index,
+            amc_chs,
+            base_ch=base_ch,
+            isLoop=isLoop,
+            dpi=dpi,
+            isBuf=isBuf,
+        )

--- a/pyMEA/presentation/plot/color.py
+++ b/pyMEA/presentation/plot/color.py
@@ -1,0 +1,25 @@
+def normalize_color(color, default_color=None):
+    """
+    color を標準化して常に list[str | list[float]] のリストにする
+
+    Args:
+        color: str | list[str] | list[float] | list[list[float]] | None
+        default_color: colorがNoneのときに使うデフォルトカラー
+
+    Returns:
+        list[str] | list[list[float]]: 正規化された色リスト
+    """
+    if color is None:
+        # デフォルトカラー
+        return [default_color]
+    elif isinstance(color, str):
+        return [color]
+    elif isinstance(color, list):
+        # RGB値1セットだけ渡された場合 [0.1, 0.2, 0.3]
+        if all(isinstance(c, (int, float)) for c in color):
+            return [color]
+        # list[str] や list[list[float]] はそのまま
+        return color
+
+    else:
+        raise TypeError("color must be str or list[str] or list[list[float]]")

--- a/pyMEA/presentation/plot/colormap.py
+++ b/pyMEA/presentation/plot/colormap.py
@@ -1,0 +1,131 @@
+"""伝導解析カラーマップ描画 (2D・3D・ライン状ネットワーク)。
+
+FigMEAの同名メソッドから呼び出される実装本体。
+"""
+
+import io
+
+from pyMEA.domain.model.Electrode import Electrode
+from pyMEA.domain.model.MEA import MEA
+from pyMEA.domain.model.peak_model import Peaks64
+from pyMEA.domain.service.gradient.Gradient import Gradient
+from pyMEA.domain.service.gradient.Gradients import Gradients
+from pyMEA.domain.service.gradient.Solver import Solver
+from pyMEA.domain.service.peak_detection import detect_peak_neg
+from pyMEA.domain.service.peak_times import (
+    remove_undetected_ch,
+    remove_undetected_ch_from64ch,
+)
+from pyMEA.presentation.plot.plot import draw_line, draw_line_conduction
+from pyMEA.presentation.video import VideoMEA
+
+
+def draw_2d(
+    data: MEA,
+    electrode: Electrode,
+    peak_index: Peaks64,
+    base_ch: int | None = None,
+    mesh_num=100,
+    contour=False,
+    isQuiver=True,
+    dpi=300,
+    cmap="jet",
+    isBuf=False,
+) -> VideoMEA | list[Gradient]:
+    """
+    2Dカラーマップ描画
+    """
+    if base_ch:
+        # 基準電極が指定されていたらその電極の拍動周期ごとにピーク抽出する
+        result = []
+        for divided_data in data.from_beat_cycles(peak_index, base_ch):
+            peak = detect_peak_neg(divided_data)
+            times, remove_ch = remove_undetected_ch_from64ch(data, peak)
+            grad = Gradient(Solver(times[0], remove_ch, electrode.ele_dis, mesh_num))
+            buf: io.BytesIO = grad.draw2d(contour, isQuiver, dpi=dpi, cmap=cmap, isBuf=isBuf)
+
+            if isBuf:
+                result.append(buf)
+            else:
+                result.append(grad)
+        if isBuf:
+            # list[BytesIO]を渡してもlist[FigImage]にキャストされる
+            return VideoMEA(result)
+        else:
+            return result
+
+    else:
+        grads = Gradients(data, peak_index, electrode.ele_dis, mesh_num)
+        buf_list = grads.draw_2d(contour, isQuiver, dpi=dpi, cmap=cmap, isBuf=isBuf)
+
+        if isBuf:
+            return VideoMEA(buf_list)
+        else:
+            return grads.gradients
+
+
+def draw_3d(
+    data: MEA,
+    electrode: Electrode,
+    peak_index: Peaks64,
+    mesh_num=100,
+    xlabel="X (μm)",
+    ylabel="Y (μm)",
+    clabel="Δt (ms)",
+    dpi=300,
+    isBuf=False,
+) -> VideoMEA | Gradients:
+    """
+    3Dカラーマップ描画
+    """
+    grads = Gradients(data, peak_index, electrode.ele_dis, mesh_num)
+    buf_list = grads.draw_3d(xlabel, ylabel, clabel, dpi, isBuf=isBuf)
+
+    if isBuf:
+        return VideoMEA(buf_list)
+    else:
+        return grads
+
+
+def draw_line_conduction_map(
+    data: MEA,
+    electrode: Electrode,
+    peak_index: Peaks64,
+    amc_chs: list[int],
+    base_ch: int | None = None,
+    isLoop=True,
+    dpi=300,
+    isBuf=False,
+) -> VideoMEA | None:
+    """
+    ライン状心筋細胞ネットワークのカラーマップ描画
+    """
+    if base_ch:
+        # 基準電極が指定されていたらその電極の拍動周期ごとにピーク抽出する
+        if base_ch not in amc_chs:
+            raise ValueError("基準電極はAMC内の電極から選択してください")
+
+        result = []
+        for divided_data in data.from_beat_cycles(peak_index, base_ch):
+            peak = detect_peak_neg(divided_data)
+            times, remove_ch_index = remove_undetected_ch(divided_data, peak, amc_chs)
+            result.append(
+                draw_line(
+                    times[0],
+                    amc_chs,
+                    remove_ch_index,
+                    electrode,
+                    isLoop,
+                    dpi,
+                    isBuf=isBuf,
+                )
+            )
+        if isBuf:
+            return VideoMEA(result)
+    else:
+        buf_list = draw_line_conduction(
+            data, electrode, peak_index, amc_chs, isLoop, dpi, isBuf=isBuf
+        )
+
+        if isBuf:
+            return VideoMEA(buf_list)

--- a/pyMEA/presentation/plot/plot.py
+++ b/pyMEA/presentation/plot/plot.py
@@ -1,4 +1,3 @@
-import statistics
 from typing import List
 
 import matplotlib.pyplot as plt
@@ -7,9 +6,10 @@ from matplotlib.collections import LineCollection
 from numpy import ndarray
 
 from pyMEA.domain.model.Electrode import Electrode
-from pyMEA.presentation.video import FigImage
-from pyMEA.domain.model.peak_model import Peaks64
 from pyMEA.domain.model.MEA import MEA
+from pyMEA.domain.model.peak_model import Peaks64
+from pyMEA.domain.service.peak_times import remove_undetected_ch
+from pyMEA.presentation.FigImage import FigImage
 from pyMEA.presentation.output import output_buf
 
 circuit_eles = [
@@ -262,26 +262,3 @@ def linear_interpolation_path(
     )
 
     return x_fine, y_fine, t_fine
-
-
-def remove_undetected_ch(data: MEA, peak_index: Peaks64, chs: list[int]):
-    # ピークの時刻 (s)を取得
-    time = [data[0][peak_index[ch]] for ch in chs]
-
-    # 各電極の取得ピーク数の最頻値以外の電極は削除
-    peaks = [len(peak_index[ch]) for ch in chs]
-    remove_ch_index = []
-    for i in range(len(time)):
-        if len(time[i]) != statistics.mode(peaks):
-            remove_ch_index.append(i)
-
-    # ピークを正しく検出できていないchのデータを削除
-    for ch in sorted(remove_ch_index, reverse=True):
-        time.pop(ch)
-    print("弾いた電極番号: ", np.array(remove_ch_index))
-
-    times = []
-    for j in range(len(time[0])):
-        times.append([time[i][j] for i in range(len(time))])
-
-    return np.array(times), remove_ch_index

--- a/pyMEA/presentation/plot/waveform.py
+++ b/pyMEA/presentation/plot/waveform.py
@@ -1,0 +1,184 @@
+"""波形描画 (全電極・単一電極・ピーク重畳・スペクトラム)。
+
+FigMEAの同名メソッドから呼び出される実装本体。
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.signal import welch
+
+from pyMEA.constants import ELECTRODE_GRID_SIZE
+from pyMEA.domain.model.MEA import MEA
+from pyMEA.domain.model.peak_model import Peaks64
+from pyMEA.presentation.output import channel, output_buf
+from pyMEA.presentation.plot.color import normalize_color
+
+
+@channel
+@output_buf
+def plot_spectrum(
+    data: MEA, ch: int, max_freq=500, nperseg=2048, figsize=(10, 4), dpi=100, isBuf=False
+):
+    """
+    与えられた信号のスペクトルをプロットする関数
+    - FFTの振幅スペクトル
+    """
+    N = len(data[ch])
+
+    # === FFT ===
+    fft_vals = np.fft.rfft(data[ch])
+    fft_freq = np.fft.rfftfreq(N, 1 / data.SAMPLING_RATE)
+    amplitude = np.abs(fft_vals) / N
+
+    # === Welch ===
+    f, Pxx = welch(data[ch], fs=data.SAMPLING_RATE, nperseg=nperseg)
+
+    # === プロット ===
+    plt.figure(figsize=figsize, dpi=dpi)
+
+    # FFT
+    plt.plot(fft_freq, amplitude)
+    plt.xlim(0, max_freq)
+    plt.xticks(np.arange(0, max_freq + 50, 50))
+    plt.xlabel("Frequency [Hz]")
+    plt.ylabel("Amplitude")
+    plt.grid()
+
+    plt.tight_layout()
+
+
+@output_buf
+def show_all(
+    data: MEA,
+    start=None,
+    end=5,
+    volt_min=-200,
+    volt_max=200,
+    figsize=(8, 8),
+    dpi=300,
+    color: list[str] | list[list[float]] = None,
+    isBuf=False,
+):
+    """
+    64電極すべての波形を描画する
+    """
+    # 時間の設定がない場合はデータの最初から5秒間をプロットする。
+    if start is None:
+        start = data.start
+    if end is None:
+        end = start + 5
+
+    # 読み込み開始時間が0ではないときズレが生じるため差を取っている
+    start_frame = int(abs(data.start - start) * data.SAMPLING_RATE)
+    end_frame = int(abs(data.start - end) * data.SAMPLING_RATE)
+
+    x = data.array[0][start_frame:end_frame]
+
+    color = normalize_color(color)
+
+    fig, axes = plt.subplots(
+        ELECTRODE_GRID_SIZE, ELECTRODE_GRID_SIZE, figsize=figsize, dpi=dpi
+    )
+    color_index = 0
+    for i, ax in enumerate(axes.flat):
+        if color is None:
+            # 配色指定あり
+            ax.plot(x, data.array[i + 1][start_frame:end_frame])
+        else:
+            # 配色指定なし
+            ax.plot(
+                x,
+                data.array[i + 1][start_frame:end_frame],
+                color=color[color_index],
+            )
+            color_index += 1
+            if color_index >= len(color):
+                color_index = 0
+        ax.set_ylim(volt_min, volt_max)
+
+
+@channel
+@output_buf
+def show_single(
+    data: MEA,
+    ch: int,
+    start: int,
+    end: int,
+    volt_min=-200,
+    volt_max=200,
+    figsize=(8, 2),
+    dpi=None,
+    xlabel="Time (s)",
+    ylabel="Voltage (μV)",
+    color: str = None,
+    isBuf=False,
+):
+    """
+    1電極の波形を描画する
+    """
+    # 読み込み開始時間が0ではないときズレが生じるため差を取っている
+    start_frame = int(abs(data.start - start) * data.SAMPLING_RATE)
+    end_frame = int(abs(data.start - end) * data.SAMPLING_RATE)
+
+    plt.figure(figsize=figsize, dpi=dpi)
+    plt.plot(
+        data.array[0][start_frame:end_frame],
+        data.array[ch][start_frame:end_frame],
+        color=color,
+    )
+    plt.xlim(start, end)
+    plt.ylim(volt_min, volt_max)
+    plt.xlabel(xlabel)
+    plt.ylabel(ylabel)
+
+
+@channel
+@output_buf
+def plot_peaks(
+    data: MEA,
+    ch: int,
+    *peak_indexes: Peaks64,
+    start: int,
+    end: int,
+    volt_min=-200,
+    volt_max=200,
+    figsize=(8, 2),
+    dpi=None,
+    xlabel="Time (s)",
+    ylabel="Voltage (μV)",
+    color: str = None,
+    peak_color: list[str] | list[list[float]] = None,
+    isBuf=False,
+):
+    """
+    1電極の波形とピークの位置をプロット
+    """
+    # 読み込み開始時間が0ではないときズレが生じるため差を取っている
+    start_frame = int(abs(data.start - start) * data.SAMPLING_RATE)
+    end_frame = int(abs(data.start - end) * data.SAMPLING_RATE)
+
+    # 波形データのプロット
+    plt.figure(figsize=figsize, dpi=dpi)
+    x, y = (
+        data.array[0][start_frame:end_frame],
+        data.array[ch][start_frame:end_frame],
+    )
+    plt.plot(x, y, color=color)
+
+    # ピークのプロット
+    peak_color = normalize_color(peak_color, "red")
+    peak_color_index = 0
+    for peak_index in peak_indexes:
+        peaks = peak_index[ch]
+        peaks = peaks[start_frame < peaks]
+        peaks = peaks[peaks < end_frame]
+        plt.plot(x[peaks], y[peaks], ".", color=peak_color[peak_color_index])
+
+        peak_color_index += 1
+        if peak_color_index >= len(peak_color):
+            peak_color_index = 0
+
+    plt.xlim(start, end)
+    plt.ylim(volt_min, volt_max)
+    plt.xlabel(xlabel)
+    plt.ylabel(ylabel)


### PR DESCRIPTION
## 概要

DDDリファクタリング Phase 3（全4フェーズ）。Phase 2 (#43) の上に積んでいます。
**公開APIのシグネチャ・挙動は不変**（Phase 1の回帰テスト + 実データE2Eスモークで確認済み）。

## 変更内容

### 責務分割
- **FigMEA (512行) を薄いファサード化**: 同名メソッドはそのまま、実装本体を分割
  - 波形描画 (\`showAll\`/\`showSingle\`/\`plotPeaks\`/\`plot_spectrum\`) → \`presentation/plot/waveform.py\`
  - カラーマップ (\`draw_2d\`/\`draw_3d\`/\`draw_line_conduction\`) → \`presentation/plot/colormap.py\`
  - 色正規化 → \`presentation/plot/color.py\`

### 重複解消
- \`get_mesh\` の3重定義（Electrode / Solver / 旧old_ver_gradient）→ \`domain/model/Electrode.py\` の関数に一本化
- \`remove_undetected_ch\` / \`remove_undetected_ch_from64ch\` の2重実装（plot.py / Gradients.py）→ \`domain/service/peak_times.py\` に一本化（64ch版は汎用版への委譲に）
- \`detect_peak_neg\`/\`detect_peak_pos\` の約70%重複ループ → \`_detect_peaks_by_ch\` 共通関数に抽出
- \`PyMEA\` の5変換メソッド（from_slice 等）の再構築コードの重複 → \`_rebuild\` ヘルパーに共通化

### バグ修正
- **\`MutableMEA.__init__\`**: \`decode_hed\` の戻り値（\`HedData\` dataclass）をタプルアンパックしており、従来はインスタンス化すると必ず \`TypeError\` になっていた。属性アクセスに修正し、実データでの動作を確認

### 補足
- 計画時に挙げていた「\`Calculator.fpd()\` の破壊的操作修正」は、現行コードが既に \`array.copy()\` を使用しており非破壊だったため対応不要と判断

## テスト

- [x] \`python -m pytest test/\` → 36 passed
- [x] 実データE2E: 全FigMEAメソッド (isBuf=True)、ISI/FPD/CV/gradient_velocity、変換メソッドチェーン、MutableMEA、draw_line_conduction、mkHist