### PR TITLE
fix: Phase3・Phase4 を main へ取り込む（スタックマージの取りこぼし復旧）

### DIFF
--- a/.claude/skills/pyMEA-codegen/SKILL.md
+++ b/.claude/skills/pyMEA-codegen/SKILL.md
@@ -268,7 +268,7 @@ mea.fig.plot_spectrum(ch=6, max_freq=500)
 バースト解析モジュールは `from pyMEA import *` ではインポートされない。明示的にインポートする。
 
 ```python
-from pyMEA.find_peaks.burst import sbf_detection, sbf_single
+from pyMEA.domain.service.burst import sbf_detection, sbf_single
 
 # 64電極の同期バースト発火検出
 peak_index = detect_peak_neg(mea.data)

--- a/.claude/skills/pyMEA-codegen/references/api-reference.md
+++ b/.claude/skills/pyMEA-codegen/references/api-reference.md
@@ -383,10 +383,10 @@ video.save_mp4("out.mp4", fps=10)    # MP4保存 (libx264コーデック)
 
 ## バースト解析
 
-`pyMEA.find_peaks.burst` モジュール（`from pyMEA import *` ではインポートされない。明示的にインポートが必要）。
+`pyMEA.domain.service.burst` モジュール（`from pyMEA import *` ではインポートされない。明示的にインポートが必要）。
 
 ```python
-from pyMEA.find_peaks.burst import sbf_detection, sbf_single, peak_flatten
+from pyMEA.domain.service.burst import sbf_detection, sbf_single, peak_flatten
 ```
 
 ### 同期バースト発火検出 (64電極)
@@ -426,10 +426,10 @@ def peak_flatten(data: MEA, peak_index: Peaks64) -> ndarray
 
 ## ポワンカレプロット・自己相関
 
-`pyMEA.figure.plot.pointcare_plot` モジュール（明示的インポートが必要）。
+`pyMEA.presentation.plot.pointcare_plot` モジュール（明示的インポートが必要）。
 
 ```python
-from pyMEA.figure.plot.pointcare_plot import pointcare_plot, normalize_data, autocorrelation
+from pyMEA.presentation.plot.pointcare_plot import pointcare_plot, normalize_data, autocorrelation
 ```
 
 ```python
@@ -447,10 +447,10 @@ pointcare_plot(data, tau, dpi=300)
 
 ## アーティファクト除去
 
-`pyMEA.find_peaks.peak_detection` モジュール内（明示的インポートが必要）。
+`pyMEA.domain.service.peak_detection` モジュール内（明示的インポートが必要）。
 
 ```python
-from pyMEA.find_peaks.peak_detection import remove_artifact
+from pyMEA.domain.service.peak_detection import remove_artifact
 
 # レーザー照射などのアーティファクトを除去
 cleaned_data, remove_times = remove_artifact(

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,18 +25,26 @@ PyMEA (frozen dataclass)
   └── electrode:  Electrode  # 電極位置情報
 ```
 
-## パッケージ構成
+## パッケージ構成 (DDDレイヤー)
 
 ```
 pyMEA/
-  ├── core/        # PyMEA, Electrode, FilterType
-  ├── read/        # .hedファイル読み込み, MEAデータモデル
-  ├── figure/      # 波形描画, カラーマップ, ラスタープロット, ヒストグラム, 動画
-  ├── calculator/  # ISI, FPD, 伝導速度の計算
-  ├── find_peaks/  # ピーク検出, バースト解析
-  ├── gradient/    # 勾配解析, 速度ベクトル計算
-  └── utils/       # フィルタ, デコレータ, パラメータ
+  ├── domain/              # 外部I/O・matplotlibに依存しない
+  │   ├── model/           # MEA, Electrode, FilterType, HedPath, BioPath, HedData, peak_model
+  │   ├── value/           # AbstractValues, ISI, FPD, ConductionVelocity
+  │   ├── service/         # peak_detection, burst, calculator, FilterMEA, CardioAveWave, peak_times, gradient/
+  │   └── validators.py    # ch_validator, time_validator
+  ├── application/         # PyMEAファサード, read_MEA, MutableMEA
+  ├── infrastructure/      # read_bio (.hed/.bioファイルI/O)
+  ├── presentation/        # FigMEA, video, FigImage, output, value_plots, gradient_plots, plot/
+  ├── constants.py         # NUM_ELECTRODES, ELECTRODE_GRID_SIZE 等の定数
+  └── __init__.py          # 公開API (PEP 562の遅延エクスポート)
 ```
+
+**依存方向ルール**: domain → なし / infrastructure → domain / presentation → domain / application → 全層。逆方向は禁止。
+
+- ドメイン層の描画メソッド (`ISI.show()`, `Gradient.draw2d()` 等) は presentation 層の実装へ遅延importで委譲する (domainのimport時にmatplotlibを読み込まない)
+- 公開API (`pyMEA/__init__.py` の `__all__`) は利用者との契約。シグネチャ・入出力を変更しないこと。`test/src/unit/test_public_api.py` が回帰テストとして守っている
 
 ## 技術スタック
 
@@ -54,7 +62,7 @@ pyMEA/
 - **イミュータブル設計**: 全主要クラスが `@dataclass(frozen=True)` を使用。MEAクラスの `array` も `setflags(write=False)` で凍結
 - **新インスタンス生成**: データ変換時は常に新しいインスタンスを返す (`from_slice`, `init_time`, `down_sampling` 等)
 - **電極番号**: 1-64 (8x8グリッド)。`array[0]` は時間データ、`array[1]`〜`array[64]` が電極データ
-- **デコレータパターン**: `@channel` (電極番号バリデーション), `@output_buf` (画像バッファ出力切替), `@ch_validator`
+- **デコレータパターン**: `@ch_validator`, `@time_validator` (入力バリデーション, `domain/validators.py`) / `@channel`, `@output_buf` (描画出力切替, `presentation/output.py`)
 
 ## テスト
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ pip install git+https://github.com/kkito0726/MEA_modules.git
 <pre>
 MEA_modules
 ├──pyMEA
-   ├── calculator # Utilities for calculating ISI, FPD, conduction velocity, and more
-   ├── figure     # Tools for plotting and visualizing data
-   ├── find_peaks # Tools for peak detection in waveform
-   ├── gradient   # Gradient analysis and related computations
-   ├── read       # Reading MEA recording file
+   ├── domain         # Core models, values, and services (MEA, ISI, FPD, peak detection, gradient, ...)
+   ├── application    # Use cases (read_MEA, PyMEA facade, MutableMEA)
+   ├── infrastructure # Reading MEA recording files (.hed/.bio)
+   ├── presentation   # Plotting and visualization (FigMEA, VideoMEA)
+   ├── constants.py   # Shared constants
+   └── __init__.py    # Public API
 </pre>
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ electrode_distance = 450 # Distance between electrodes (μm)
 mea = read_MEA(hed_path, start, end, electrode_distance)
 
 # Detecting peaks in the waveform
-peak_index_neg = detect_peak_neg(mea.data) # Detect positive peaks
-peak_index_pos = detect_peak_pos(mea.data) # Detect negative peaks
+peak_index_neg = detect_peak_neg(mea.data) # Detect negative peaks
+peak_index_pos = detect_peak_pos(mea.data) # Detect positive peaks
 
 ch = 6 # electrode number
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -119,7 +119,7 @@ mea = read_MEA(hed_path, start, end, electrode_distance, FilterType.CARDIO_AVE_W
 ### データの分割
 ```python
 # 読み込んだデータを任意の期間切り出す
-# read_MEAでは読み込み期間を整数でしか指定できないがここでは少数も可能
+# read_MEAでは読み込み期間を整数でしか指定できないがここでは小数も可能
 mea_slice = mea.from_slice(0.25, 0.5)
 
 # 拍動周期ごとにデータを切り出す
@@ -137,7 +137,7 @@ mea = mea.init_time()
 ### 電位データのダウンサンプリング
 ```python
 # 1/10にダウンサンプリングする
-dawn_sampled_mea = mea.down_sampling(10)
+down_sampled_mea = mea.down_sampling(10)
 ```
 ---
 ## ピーク抽出
@@ -160,11 +160,11 @@ def detect_peak_pos(
 
 def detect_peak_all(
     MEA_data: MEA,
-    threshold: tuple[int, int] = (3, 3), # (上, 下)
-    distance=3000, # SD * thresholdより大きいピークを取る
-    min_amp=(10, 10), # (上, 下)
-    width=None,
+    threshold: tuple[int, int] = (3, 3), # SD * thresholdより大きいピークを取る (上, 下)
+    distance=3000, # ピークを取る間隔
+    min_amp=(10, 10), # 最小のピークの閾値電位 (上, 下)
     prominence=None,
+    width=None,
 ) -> AllPeaks64:
 ```
 ```python
@@ -186,8 +186,8 @@ def showAll(
         self,
         start=None,     # 描画開始時間 (s)
         end=5,          # 描画終了時間 (s)
-        volt_min=-200,  # 最大電位 (μV)
-        volt_max=200,   # 最小電位 (μV)
+        volt_min=-200,  # 最小電位 (μV)
+        volt_max=200,   # 最大電位 (μV)
         figsize=(8, 8), # グラフの縦横比
         dpi=300,        # 解像度
         color: list[str] | list[list[float]] = None, # 波形の配色
@@ -461,25 +461,25 @@ fpd_stv = fpd.stv # FPDのSTV (Short-Term Variability)を計算
 fpd_cv = fpd.coefficient_of_variation # FPDのCV (変動係数, Coefficient of Variation)を計算
 
 # FPD算出のために抽出したピークの位置を確認する
-fpd.show(mea.data)
+fpd.show()
 ```
 
 ### 伝導速度の計算
 
 ```python
-def conduction_velocity(self, peak_index: Peaks64, ch1: int, ch2: int) -> ndarray:
+def conduction_velocity(self, peak_index: Peaks64, ch1: int, ch2: int) -> ConductionVelocity:
 ```
 
 ```python
 # サンプルコード
-# ch 9とch 54間の伝導速度を算出する
+# ch 9とch 54間の伝導速度 (m/s)を算出する
 peak_index = detect_peak_neg(mea.data)
 conduction_velocity = mea.calculator.conduction_velocity(peak_index, ch1=9, ch2=54)
-mean = fpd.mean # 算出された伝導速度の平均値
-std = fpd.std # 算出された伝導速度の標準偏差
-se = fpd.se # 算出された伝導速度の標準誤差
-stv = fpd.stv # 伝導速度のSTV (Short-Term Variability)を計算
-cv = fpd.coefficient_of_variation # 伝導速度のCV (変動係数, Coefficient of Variation)を計算
+mean = conduction_velocity.mean # 算出された伝導速度の平均値
+std = conduction_velocity.std # 算出された伝導速度の標準偏差
+se = conduction_velocity.se # 算出された伝導速度の標準誤差
+stv = conduction_velocity.stv # 伝導速度のSTV (Short-Term Variability)を計算
+cv = conduction_velocity.coefficient_of_variation # 伝導速度のCV (変動係数, Coefficient of Variation)を計算
 ```
 
 ### 電極間距離の計算 (直線距離を計算)

--- a/pyMEA/application/MutableMEA.py
+++ b/pyMEA/application/MutableMEA.py
@@ -18,7 +18,9 @@ class MutableMEA:
         self.start: int = start
         self.end: int = end
         self.time: int = end - start
-        self.SAMPLING_RATE, self.GAIN = decode_hed(self.hed_path)
+        hed_data = decode_hed(self.hed_path)
+        self.SAMPLING_RATE = hed_data.SAMPLING_RATE
+        self.GAIN = hed_data.GAIN
         self.array = hed2array(self.hed_path, self.start, self.end)
 
     def __repr__(self):

--- a/pyMEA/application/PyMEA.py
+++ b/pyMEA/application/PyMEA.py
@@ -43,51 +43,34 @@ class PyMEA:
     def __floordiv__(self, value):
         return self.data.array // value
 
+    def _rebuild(self, new_data: MEA) -> "PyMEA":
+        """変換後のMEAデータから各責務クラスを再構築したPyMEAを返す"""
+        return PyMEA(
+            new_data,
+            self.electrode,
+            FigMEA(new_data, self.electrode),
+            Calculator(new_data, self.electrode.ele_dis),
+        )
+
     def from_slice(self, start: int | float, end: int | float):
         start_frame, end_frame = (
             int((start - self.data.start) * self.data.SAMPLING_RATE),
             int((end - self.data.start) * self.data.SAMPLING_RATE),
         )
-        new_data = self.data.from_slice(start_frame, end_frame)
-        return PyMEA(
-            new_data,
-            self.electrode,
-            FigMEA(new_data, self.electrode),
-            Calculator(new_data, self.electrode.ele_dis),
-        )
+        return self._rebuild(self.data.from_slice(start_frame, end_frame))
 
     def from_beat_cycles(
         self, peak_index: Peaks64, base_ch: int, margin_time: float = 0.25
     ):
         new_data_list = self.data.from_beat_cycles(peak_index, base_ch, margin_time)
-        return [
-            PyMEA(
-                new_data,
-                self.electrode,
-                FigMEA(new_data, self.electrode),
-                Calculator(new_data, self.electrode.ele_dis),
-            )
-            for new_data in new_data_list
-        ]
+        return [self._rebuild(new_data) for new_data in new_data_list]
 
     def init_time(self):
         """時刻データを0 (s)からにしたMEAインスタンスを返却"""
-        new_data = self.data.init_time()
-        return PyMEA(
-            new_data,
-            self.electrode,
-            FigMEA(new_data, self.electrode),
-            Calculator(new_data, self.electrode.ele_dis),
-        )
+        return self._rebuild(self.data.init_time())
 
     def down_sampling(self, down_sampling_rate=100):
-        new_data = self.data.down_sampling(down_sampling_rate)
-        return PyMEA(
-            new_data,
-            self.electrode,
-            FigMEA(new_data, self.electrode),
-            Calculator(new_data, self.electrode.ele_dis),
-        )
+        return self._rebuild(self.data.down_sampling(down_sampling_rate))
 
     def iirnotch_filter(self, filter_hz=50, Q=30):
         """
@@ -105,10 +88,4 @@ class PyMEA:
         filtered : PyMEA
             フィルタ後の信号
         """
-        new_data = self.data.iirnotch_filter(filter_hz, Q)
-        return PyMEA(
-            new_data,
-            self.electrode,
-            FigMEA(new_data, self.electrode),
-            Calculator(new_data, self.electrode.ele_dis),
-        )
+        return self._rebuild(self.data.iirnotch_filter(filter_hz, Q))

--- a/pyMEA/domain/model/Electrode.py
+++ b/pyMEA/domain/model/Electrode.py
@@ -5,7 +5,31 @@ import numpy as np
 from numpy import float64
 from numpy._typing import NDArray
 
+from pyMEA.constants import ELECTRODE_GRID_SIZE
 from pyMEA.domain.validators import ch_validator
+
+
+def get_mesh(
+    ele_dis: int, mesh_num: int
+) -> tuple[NDArray[float64], NDArray[float64]]:
+    """
+    電極エリアを mesh_num x mesh_num に分割したグリッド配列を取得する
+    """
+    # データ範囲を取得
+    x_min, x_max = 0, ele_dis * (ELECTRODE_GRID_SIZE - 1)
+    y_min, y_max = 0, ele_dis * (ELECTRODE_GRID_SIZE - 1)
+
+    # 取得したデータ範囲で新しく座標にする配列を作成
+    x_coord = np.linspace(x_min, x_max, mesh_num)
+    y_coord = np.linspace(y_min, y_max, mesh_num)
+
+    # 取得したデータ範囲で新しく座標にする配列を作成
+    xx, yy = np.meshgrid(x_coord, y_coord)
+
+    # 電極番号順に配列を修正
+    yy = np.rot90(np.rot90(yy))
+
+    return xx, yy
 
 
 @dataclass(frozen=True)
@@ -17,21 +41,7 @@ class Electrode:
         """
         電極のグリッド配列 (8 x 8)を取得するメソッド
         """
-        # データ範囲を取得
-        x_min, x_max = 0, self.ele_dis * 7
-        y_min, y_max = 0, self.ele_dis * 7
-
-        # 取得したデータ範囲で新しく座標にする配列を作成
-        x_coord = np.linspace(x_min, x_max, 8)
-        y_coord = np.linspace(y_min, y_max, 8)
-
-        # 取得したデータ範囲で新しく座標にする配列を作成
-        xx, yy = np.meshgrid(x_coord, y_coord)
-
-        # 電極番号順に配列を修正
-        yy = np.rot90(np.rot90(yy))
-
-        return xx, yy
+        return get_mesh(self.ele_dis, ELECTRODE_GRID_SIZE)
 
     @ch_validator
     def get_coordinate(self, ch: int) -> tuple[NDArray[float64], NDArray[float64]]:
@@ -46,6 +56,6 @@ class Electrode:
 
         """
         mesh = self.get_electrode_mesh
-        x = mesh[0][(ch - 1) // 8][(ch - 1) % 8]
-        y = mesh[1][(ch - 1) // 8][(ch - 1) % 8]
+        x = mesh[0][(ch - 1) // ELECTRODE_GRID_SIZE][(ch - 1) % ELECTRODE_GRID_SIZE]
+        y = mesh[1][(ch - 1) // ELECTRODE_GRID_SIZE][(ch - 1) % ELECTRODE_GRID_SIZE]
         return x, y

--- a/pyMEA/domain/service/gradient/Gradients.py
+++ b/pyMEA/domain/service/gradient/Gradients.py
@@ -1,17 +1,16 @@
-import statistics
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-import numpy as np
 from numpy import float64
 from numpy._typing import NDArray
 
-from pyMEA.constants import DEFAULT_ELECTRODE_DISTANCE, NUM_ELECTRODES
+from pyMEA.constants import DEFAULT_ELECTRODE_DISTANCE
 from pyMEA.domain.model.MEA import MEA
 from pyMEA.domain.model.peak_model import Peaks64
 from pyMEA.domain.service.gradient.Gradient import Gradient
 from pyMEA.domain.service.gradient.Solver import Solver
+from pyMEA.domain.service.peak_times import remove_undetected_ch_from64ch
 
 if TYPE_CHECKING:
     from pyMEA.presentation.FigImage import FigImage
@@ -86,28 +85,3 @@ class Gradients:
         ]
         if isBuf:
             return buf_list
-
-
-def remove_undetected_ch_from64ch(
-    data: MEA, peak_index: Peaks64
-) -> tuple[list[list[np.ndarray[Any, Any]]], list[int]]:
-    # ピークの時刻 (s)を取得
-    time = [data[0][peak_index[i]] for i in range(1, NUM_ELECTRODES + 1)]
-
-    # 各電極の取得ピーク数の最頻値以外の電極は削除
-    peaks = [len(peak_index[i]) for i in range(1, NUM_ELECTRODES + 1)]
-    remove_ch = []
-    for i in range(len(time)):
-        if len(time[i]) != statistics.mode(peaks):
-            remove_ch.append(i)
-
-    # ピークを正しく検出できていないchのデータを削除
-    for ch in sorted(remove_ch, reverse=True):
-        time.pop(ch)
-    print("弾いた電極番号: ", np.array(remove_ch))
-
-    times = []
-    for j in range(len(time[0])):
-        times.append([time[i][j] for i in range(len(time))])
-
-    return times, remove_ch

--- a/pyMEA/domain/service/gradient/Solver.py
+++ b/pyMEA/domain/service/gradient/Solver.py
@@ -7,6 +7,9 @@ from numpy import float64
 from numpy._typing import NDArray
 from scipy.optimize import curve_fit
 
+from pyMEA.constants import ELECTRODE_GRID_SIZE
+from pyMEA.domain.model.Electrode import get_mesh
+
 
 @dataclass(frozen=True)
 class Solver:
@@ -56,7 +59,7 @@ class Solver:
             popt: モデル式の係数が入ったリスト
             r2: 決定係数
         """
-        xx, yy = get_mesh(self.ele_dis, 8)
+        xx, yy = get_mesh(self.ele_dis, ELECTRODE_GRID_SIZE)
         xx = np.delete(xx, self.remove_ch)
         yy = np.delete(yy, self.remove_ch)
 
@@ -68,27 +71,6 @@ class Solver:
         r2 = 1 - (rss / tss)
 
         return np.array(popt), r2
-
-
-def get_mesh(ele_dis: int, mesh_num: int) -> tuple[NDArray[float64], NDArray[float64]]:
-    """
-    グリッド配列を取得するメソッド
-    """
-    # データ範囲を取得
-    x_min, x_max = 0, ele_dis * 7
-    y_min, y_max = 0, ele_dis * 7
-
-    # 取得したデータ範囲で新しく座標にする配列を作成
-    x_coord = np.linspace(x_min, x_max, mesh_num)
-    y_coord = np.linspace(y_min, y_max, mesh_num)
-
-    # 取得したデータ範囲で新しく座標にする配列を作成
-    xx, yy = np.meshgrid(x_coord, y_coord)
-
-    # 電極番号順に配列を修正
-    yy = np.rot90(np.rot90(yy))
-
-    return xx, yy
 
 
 def model(

--- a/pyMEA/domain/service/peak_detection.py
+++ b/pyMEA/domain/service/peak_detection.py
@@ -14,6 +14,42 @@ from pyMEA.domain.model.peak_model import (
 from pyMEA.domain.model.MEA import MEA
 
 
+def _detect_peaks_by_ch(
+    MEA_data: MEA,
+    is_positive: bool,
+    distance,
+    threshold,
+    min_amp,
+    prominence,
+    width,
+) -> dict[int, ndarray]:
+    """全電極に対して片側 (上または下) のピーク検出を行う共通処理"""
+    peak_dict: dict[int, ndarray] = {}
+    for i in range(1, len(MEA_data)):
+        # ピーク抽出の閾値を設定
+        height = np.std(MEA_data[i]) * threshold
+        # 閾値が最低閾値を下回っていた場合は最低閾値の値を閾値の値に設定する
+        if height < min_amp:
+            height = min_amp
+
+        data = MEA_data.array[i].copy()
+        if is_positive:
+            data[data < 0] = 0
+        else:
+            data[data > 0] = 0
+            data = -data
+        detect_peak_index, _ = find_peaks(
+            data,
+            height=height,
+            distance=distance,
+            prominence=prominence,
+            width=width,
+        )
+        peak_dict[i] = detect_peak_index
+
+    return peak_dict
+
+
 # 64電極すべての下ピークを取得
 def detect_peak_neg(
     MEA_data: MEA,
@@ -34,26 +70,16 @@ def detect_peak_neg(
         prominence: 突起度
         width: ピークの幅
     """
-    peak_dict: dict[int, NegPeaks] = {}
-    for i in range(1, len(MEA_data)):
-        # ピーク抽出の閾値を設定
-        height = np.std(MEA_data[i]) * threshold
-        # 閾値が最低閾値を下回っていた場合は最低閾値の値を閾値の値に設定する
-        if height < min_amp:
-            height = min_amp
-
-        data = MEA_data.array[i].copy()
-        data[data > 0] = 0
-        detect_peak_index, _ = find_peaks(
-            -data,
-            height=height,
-            distance=distance,
-            prominence=prominence,
-            width=width,
-        )
-        peak_dict[i] = NegPeaks(detect_peak_index)
-
-    return NegPeaks64(peak_dict)
+    peak_dict = _detect_peaks_by_ch(
+        MEA_data,
+        is_positive=False,
+        distance=distance,
+        threshold=threshold,
+        min_amp=min_amp,
+        prominence=prominence,
+        width=width,
+    )
+    return NegPeaks64({ch: NegPeaks(peaks) for ch, peaks in peak_dict.items()})
 
 
 # 64電極すべての上ピークを取得
@@ -76,26 +102,16 @@ def detect_peak_pos(
         prominence: 突起度
         width: ピークの幅
     """
-    peak_dict: dict[int, PosPeaks] = {}
-    for i in range(1, len(MEA_data)):
-        # ピーク抽出の閾値を設定
-        height = np.std(MEA_data[i]) * threshold
-        # 閾値が最低閾値を下回っていた場合は最低閾値の値を閾値の値に設定する
-        if height < min_amp:
-            height = min_amp
-
-        data = MEA_data.array[i].copy()
-        data[data < 0] = 0
-        detect_peak_index, _ = find_peaks(
-            data,
-            height=height,
-            distance=distance,
-            prominence=prominence,
-            width=width,
-        )
-        peak_dict[i] = PosPeaks(detect_peak_index)
-
-    return PosPeaks64(peak_dict)
+    peak_dict = _detect_peaks_by_ch(
+        MEA_data,
+        is_positive=True,
+        distance=distance,
+        threshold=threshold,
+        min_amp=min_amp,
+        prominence=prominence,
+        width=width,
+    )
+    return PosPeaks64({ch: PosPeaks(peaks) for ch, peaks in peak_dict.items()})
 
 
 def detect_cardio_second_peak(

--- a/pyMEA/domain/service/peak_times.py
+++ b/pyMEA/domain/service/peak_times.py
@@ -1,0 +1,52 @@
+"""ピーク時刻行列の生成と、ピーク未検出電極の除去。
+
+各電極のピーク検出数の最頻値と異なる電極 (ピークを正しく検出できていない電極)
+を除外し、拍動周期ごとのピーク時刻行列を返す。
+"""
+
+import statistics
+
+import numpy as np
+
+from pyMEA.constants import NUM_ELECTRODES
+from pyMEA.domain.model.MEA import MEA
+from pyMEA.domain.model.peak_model import Peaks64
+
+
+def remove_undetected_ch(
+    data: MEA, peak_index: Peaks64, chs: list[int]
+) -> tuple[np.ndarray, list[int]]:
+    """
+    指定電極のうちピーク未検出の電極を除去したピーク時刻行列を返す
+
+    Returns:
+        times: 拍動周期ごとのピーク時刻行列 (s)
+        remove_ch_index: 除去した電極のchsにおけるインデックス
+    """
+    # ピークの時刻 (s)を取得
+    time = [data[0][peak_index[ch]] for ch in chs]
+
+    # 各電極の取得ピーク数の最頻値以外の電極は削除
+    peaks = [len(peak_index[ch]) for ch in chs]
+    mode_peaks = statistics.mode(peaks)
+    remove_ch_index = [i for i in range(len(time)) if len(time[i]) != mode_peaks]
+
+    # ピークを正しく検出できていないchのデータを削除
+    for ch in sorted(remove_ch_index, reverse=True):
+        time.pop(ch)
+    print("弾いた電極番号: ", np.array(remove_ch_index))
+
+    times = np.array(
+        [[time[i][j] for i in range(len(time))] for j in range(len(time[0]))]
+    )
+
+    return times, remove_ch_index
+
+
+def remove_undetected_ch_from64ch(
+    data: MEA, peak_index: Peaks64
+) -> tuple[np.ndarray, list[int]]:
+    """
+    全64電極のうちピーク未検出の電極を除去したピーク時刻行列を返す
+    """
+    return remove_undetected_ch(data, peak_index, list(range(1, NUM_ELECTRODES + 1)))

--- a/pyMEA/presentation/FigMEA.py
+++ b/pyMEA/presentation/FigMEA.py
@@ -1,66 +1,30 @@
-import io
 from dataclasses import dataclass
 
-import matplotlib.pyplot as plt
 import numpy as np
-from scipy.signal import welch
 
-from pyMEA.constants import ELECTRODE_GRID_SIZE
 from pyMEA.domain.model.Electrode import Electrode
-from pyMEA.presentation.plot.histogram import mkHist
-from pyMEA.presentation.plot.plot import (
-    draw_line,
-    draw_line_conduction,
-    remove_undetected_ch,
-    showDetection,
-)
-from pyMEA.presentation.plot.raster_plot import raster_plot
-from pyMEA.presentation.video import FigImage, VideoMEA
-from pyMEA.domain.service.peak_detection import detect_peak_neg
+from pyMEA.domain.model.MEA import MEA
 from pyMEA.domain.model.peak_model import Peaks64
 from pyMEA.domain.service.gradient.Gradient import Gradient
-from pyMEA.domain.service.gradient.Gradients import Gradients, remove_undetected_ch_from64ch
-from pyMEA.domain.service.gradient.Solver import Solver
-from pyMEA.domain.model.MEA import MEA
-from pyMEA.presentation.output import channel, output_buf
+from pyMEA.domain.service.gradient.Gradients import Gradients
+from pyMEA.presentation.FigImage import FigImage
+from pyMEA.presentation.plot import colormap, waveform
+from pyMEA.presentation.plot.color import normalize_color
+from pyMEA.presentation.plot.histogram import mkHist
+from pyMEA.presentation.plot.plot import showDetection
+from pyMEA.presentation.plot.raster_plot import raster_plot
+from pyMEA.presentation.video import VideoMEA
 
 
 @dataclass(frozen=True)
 class FigMEA:
+    """グラフ描画のファサード。
+
+    各メソッドの実装本体は presentation/plot/ 配下の小モジュールにある。
+    """
+
     data: MEA
     electrode: Electrode
-
-    @channel
-    @output_buf
-    def plot_spectrum(
-        self, ch: int, max_freq=500, nperseg=2048, figsize=(10, 4), dpi=100, isBuf=False
-    ):
-        """
-        与えられた信号のスペクトルをプロットする関数
-        - FFTの振幅スペクトル
-        """
-        N = len(self.data[ch])
-
-        # === FFT ===
-        fft_vals = np.fft.rfft(self.data[ch])
-        fft_freq = np.fft.rfftfreq(N, 1 / self.data.SAMPLING_RATE)
-        amplitude = np.abs(fft_vals) / N
-
-        # === Welch ===
-        f, Pxx = welch(self.data[ch], fs=self.data.SAMPLING_RATE, nperseg=nperseg)
-
-        # === プロット ===
-        plt.figure(figsize=figsize, dpi=dpi)
-
-        # FFT
-        plt.plot(fft_freq, amplitude)
-        plt.xlim(0, max_freq)
-        plt.xticks(np.arange(0, max_freq + 50, 50))
-        plt.xlabel("Frequency [Hz]")
-        plt.ylabel("Amplitude")
-        plt.grid()
-
-        plt.tight_layout()
 
     def _set_times(self, start, end) -> tuple[int, int]:
         # 時間の設定がなければ読み込み時間全体をプロットするようにする。
@@ -71,7 +35,23 @@ class FigMEA:
 
         return start, end
 
-    @output_buf
+    def plot_spectrum(
+        self, ch: int, max_freq=500, nperseg=2048, figsize=(10, 4), dpi=100, isBuf=False
+    ):
+        """
+        与えられた信号のスペクトルをプロットする関数
+        - FFTの振幅スペクトル
+        """
+        return waveform.plot_spectrum(
+            self.data,
+            ch,
+            max_freq=max_freq,
+            nperseg=nperseg,
+            figsize=figsize,
+            dpi=dpi,
+            isBuf=isBuf,
+        )
+
     def showAll(
         self,
         start=None,
@@ -96,42 +76,18 @@ class FigMEA:
             color: プロットの配色
             isBuf: グラフ画像を返すかどうか
         """
-        # 時間の設定がない場合はデータの最初から5秒間をプロットする。
-        if start is None:
-            start = self.data.start
-        if end is None:
-            end = start + 5
-
-        # 読み込み開始時間が0ではないときズレが生じるため差を取っている
-        start_frame = int(abs(self.data.start - start) * self.data.SAMPLING_RATE)
-        end_frame = int(abs(self.data.start - end) * self.data.SAMPLING_RATE)
-
-        x = self.data.array[0][start_frame:end_frame]
-
-        color = self._normalize_color(color)
-
-        fig, axes = plt.subplots(
-            ELECTRODE_GRID_SIZE, ELECTRODE_GRID_SIZE, figsize=figsize, dpi=dpi
+        return waveform.show_all(
+            self.data,
+            start=start,
+            end=end,
+            volt_min=volt_min,
+            volt_max=volt_max,
+            figsize=figsize,
+            dpi=dpi,
+            color=color,
+            isBuf=isBuf,
         )
-        color_index = 0
-        for i, ax in enumerate(axes.flat):
-            if color is None:
-                # 配色指定あり
-                ax.plot(x, self.data.array[i + 1][start_frame:end_frame])
-            else:
-                # 配色指定なし
-                ax.plot(
-                    x,
-                    self.data.array[i + 1][start_frame:end_frame],
-                    color=color[color_index],
-                )
-                color_index += 1
-                if color_index >= len(color):
-                    color_index = 0
-            ax.set_ylim(volt_min, volt_max)
 
-    @channel
-    @output_buf
     def showSingle(
         self,
         ch: int,
@@ -163,24 +119,21 @@ class FigMEA:
             isBuf: グラフ画像を返すかどうか
         """
         start, end = self._set_times(start, end)
-
-        # 読み込み開始時間が0ではないときズレが生じるため差を取っている
-        start_frame = int(abs(self.data.start - start) * self.data.SAMPLING_RATE)
-        end_frame = int(abs(self.data.start - end) * self.data.SAMPLING_RATE)
-
-        plt.figure(figsize=figsize, dpi=dpi)
-        plt.plot(
-            self.data.array[0][start_frame:end_frame],
-            self.data.array[ch][start_frame:end_frame],
+        return waveform.show_single(
+            self.data,
+            ch,
+            start,
+            end,
+            volt_min=volt_min,
+            volt_max=volt_max,
+            figsize=figsize,
+            dpi=dpi,
+            xlabel=xlabel,
+            ylabel=ylabel,
             color=color,
+            isBuf=isBuf,
         )
-        plt.xlim(start, end)
-        plt.ylim(volt_min, volt_max)
-        plt.xlabel(xlabel)
-        plt.ylabel(ylabel)
 
-    @channel
-    @output_buf
     def plotPeaks(
         self,
         ch: int,
@@ -195,14 +148,14 @@ class FigMEA:
         ylabel="Voltage (μV)",
         color: str = None,
         peak_color: list[str] | list[list[float]] = None,
-        isBuf=False
+        isBuf=False,
     ) -> FigImage | None:
         """
         1電極の波形とピークの位置をプロット
 
         Args:
             ch: 描画する電極番号
-            *peak_index: ピーク配列 (可変長)以降の引数は引数名を指定する
+            *peak_indexes: ピーク配列 (可変長)以降の引数は引数名を指定する
             start: 読み込み開始時間 [s]
             end: 読み込み終了時間[s]
             volt_min: マイナス電位 [μV]
@@ -216,36 +169,22 @@ class FigMEA:
             isBuf: グラフ画像を返すかどうか
         """
         start, end = self._set_times(start, end)
-
-        # 読み込み開始時間が0ではないときズレが生じるため差を取っている
-        start_frame = int(abs(self.data.start - start) * self.data.SAMPLING_RATE)
-        end_frame = int(abs(self.data.start - end) * self.data.SAMPLING_RATE)
-
-        # 波形データのプロット
-        plt.figure(figsize=figsize, dpi=dpi)
-        x, y = (
-            self.data.array[0][start_frame:end_frame],
-            self.data.array[ch][start_frame:end_frame],
+        return waveform.plot_peaks(
+            self.data,
+            ch,
+            *peak_indexes,
+            start=start,
+            end=end,
+            volt_min=volt_min,
+            volt_max=volt_max,
+            figsize=figsize,
+            dpi=dpi,
+            xlabel=xlabel,
+            ylabel=ylabel,
+            color=color,
+            peak_color=peak_color,
+            isBuf=isBuf,
         )
-        plt.plot(x, y, color=color)
-
-        # ピークのプロット
-        peak_color = self._normalize_color(peak_color, "red")
-        peak_color_index = 0
-        for peak_index in peak_indexes:
-            peaks = peak_index[ch]
-            peaks = peaks[start_frame < peaks]
-            peaks = peaks[peaks < end_frame]
-            plt.plot(x[peaks], y[peaks], ".", color=peak_color[peak_color_index])
-
-            peak_color_index += 1
-            if peak_color_index >= len(peak_color):
-                peak_color_index = 0
-
-        plt.xlim(start, end)
-        plt.ylim(volt_min, volt_max)
-        plt.xlabel(xlabel)
-        plt.ylabel(ylabel)
 
     def showDetection(
         self,
@@ -293,7 +232,7 @@ class FigMEA:
             xlabel=xlabel,
             ylabel=ylabel,
             dpi=dpi,
-            color=self._normalize_color(color, None),
+            color=normalize_color(color, None),
             isBuf=isBuf,
         )
         return buf
@@ -372,37 +311,18 @@ class FigMEA:
             cmap: カラーセット
             isBuf: グラフ画像を返すかどうか
         """
-        if base_ch:
-            # 基準電極が指定されていたらその電極の拍動周期ごとにピーク抽出する
-            result = []
-            for divided_data in self.data.from_beat_cycles(peak_index, base_ch):
-                peak = detect_peak_neg(divided_data)
-                times, remove_ch = remove_undetected_ch_from64ch(self.data, peak)
-                grad = Gradient(
-                    Solver(times[0], remove_ch, self.electrode.ele_dis, mesh_num)
-                )
-                buf: io.BytesIO = grad.draw2d(
-                    contour, isQuiver, dpi=dpi, cmap=cmap, isBuf=isBuf
-                )
-
-                if isBuf:
-                    result.append(buf)
-                else:
-                    result.append(grad)
-            if isBuf:
-                # list[BytesIO]を渡してもlist[FigImage]にキャストされる
-                return VideoMEA(result)
-            else:
-                return result
-
-        else:
-            grads = Gradients(self.data, peak_index, self.electrode.ele_dis, mesh_num)
-            buf_list = grads.draw_2d(contour, isQuiver, dpi=dpi, cmap=cmap, isBuf=isBuf)
-
-            if isBuf:
-                return VideoMEA(buf_list)
-            else:
-                return grads.gradients
+        return colormap.draw_2d(
+            self.data,
+            self.electrode,
+            peak_index,
+            base_ch=base_ch,
+            mesh_num=mesh_num,
+            contour=contour,
+            isQuiver=isQuiver,
+            dpi=dpi,
+            cmap=cmap,
+            isBuf=isBuf,
+        )
 
     def draw_3d(
         self,
@@ -425,13 +345,17 @@ class FigMEA:
             dpi: 解像度
             isBuf: グラフ画像を返すかどうか
         """
-        grads = Gradients(self.data, peak_index, self.electrode.ele_dis, mesh_num)
-        buf_list = grads.draw_3d(xlabel, ylabel, clabel, dpi, isBuf=isBuf)
-
-        if isBuf:
-            return VideoMEA(buf_list)
-        else:
-            return grads
+        return colormap.draw_3d(
+            self.data,
+            self.electrode,
+            peak_index,
+            mesh_num=mesh_num,
+            xlabel=xlabel,
+            ylabel=ylabel,
+            clabel=clabel,
+            dpi=dpi,
+            isBuf=isBuf,
+        )
 
     def draw_line_conduction(
         self,
@@ -448,7 +372,7 @@ class FigMEA:
         ----------
         Parameters
             peak_index: ピーク抽出結果
-            chs: AMCの電極番号配列
+            amc_chs: AMCの電極番号配列
             base_ch: 基準電極
             isLoop: 経路が環状かどうか
             dpi: 解像度
@@ -457,59 +381,13 @@ class FigMEA:
         -------
 
         """
-        if base_ch:
-            # 基準電極が指定されていたらその電極の拍動周期ごとにピーク抽出する
-            if base_ch not in amc_chs:
-                raise ValueError("基準電極はAMC内の電極から選択してください")
-
-            result = []
-            for divided_data in self.data.from_beat_cycles(peak_index, base_ch):
-                peak = detect_peak_neg(divided_data)
-                times, remove_ch_index = remove_undetected_ch(
-                    divided_data, peak, amc_chs
-                )
-                result.append(
-                    draw_line(
-                        times[0],
-                        amc_chs,
-                        remove_ch_index,
-                        self.electrode,
-                        isLoop,
-                        dpi,
-                        isBuf=isBuf,
-                    )
-                )
-            if isBuf:
-                return VideoMEA(result)
-        else:
-            buf_list = draw_line_conduction(
-                self.data, self.electrode, peak_index, amc_chs, isLoop, dpi, isBuf=isBuf
-            )
-
-            if isBuf:
-                return VideoMEA(buf_list)
-
-    def _normalize_color(self, color, default_color=None):
-        """
-        peak_color を標準化して常に list[list[float] または str] のリストにする
-
-        Args:
-            color: str | list[str] | list[float] | list[list[float]] | None
-
-        Returns:
-            list[str] | list[list[float]]: 正規化された色リスト
-        """
-        if color is None:
-            # デフォルトカラー
-            return [default_color]
-        elif isinstance(color, str):
-            return [color]
-        elif isinstance(color, list):
-            # RGB値1セットだけ渡された場合 [0.1, 0.2, 0.3]
-            if all(isinstance(c, (int, float)) for c in color):
-                return [color]
-            # list[str] や list[list[float]] はそのまま
-            return color
-
-        else:
-            raise TypeError("peak_color must be str or list[str] or list[list[float]]")
+        return colormap.draw_line_conduction_map(
+            self.data,
+            self.electrode,
+            peak_index,
+            amc_chs,
+            base_ch=base_ch,
+            isLoop=isLoop,
+            dpi=dpi,
+            isBuf=isBuf,
+        )

--- a/pyMEA/presentation/plot/color.py
+++ b/pyMEA/presentation/plot/color.py
@@ -1,0 +1,25 @@
+def normalize_color(color, default_color=None):
+    """
+    color を標準化して常に list[str | list[float]] のリストにする
+
+    Args:
+        color: str | list[str] | list[float] | list[list[float]] | None
+        default_color: colorがNoneのときに使うデフォルトカラー
+
+    Returns:
+        list[str] | list[list[float]]: 正規化された色リスト
+    """
+    if color is None:
+        # デフォルトカラー
+        return [default_color]
+    elif isinstance(color, str):
+        return [color]
+    elif isinstance(color, list):
+        # RGB値1セットだけ渡された場合 [0.1, 0.2, 0.3]
+        if all(isinstance(c, (int, float)) for c in color):
+            return [color]
+        # list[str] や list[list[float]] はそのまま
+        return color
+
+    else:
+        raise TypeError("color must be str or list[str] or list[list[float]]")

--- a/pyMEA/presentation/plot/colormap.py
+++ b/pyMEA/presentation/plot/colormap.py
@@ -1,0 +1,131 @@
+"""伝導解析カラーマップ描画 (2D・3D・ライン状ネットワーク)。
+
+FigMEAの同名メソッドから呼び出される実装本体。
+"""
+
+import io
+
+from pyMEA.domain.model.Electrode import Electrode
+from pyMEA.domain.model.MEA import MEA
+from pyMEA.domain.model.peak_model import Peaks64
+from pyMEA.domain.service.gradient.Gradient import Gradient
+from pyMEA.domain.service.gradient.Gradients import Gradients
+from pyMEA.domain.service.gradient.Solver import Solver
+from pyMEA.domain.service.peak_detection import detect_peak_neg
+from pyMEA.domain.service.peak_times import (
+    remove_undetected_ch,
+    remove_undetected_ch_from64ch,
+)
+from pyMEA.presentation.plot.plot import draw_line, draw_line_conduction
+from pyMEA.presentation.video import VideoMEA
+
+
+def draw_2d(
+    data: MEA,
+    electrode: Electrode,
+    peak_index: Peaks64,
+    base_ch: int | None = None,
+    mesh_num=100,
+    contour=False,
+    isQuiver=True,
+    dpi=300,
+    cmap="jet",
+    isBuf=False,
+) -> VideoMEA | list[Gradient]:
+    """
+    2Dカラーマップ描画
+    """
+    if base_ch:
+        # 基準電極が指定されていたらその電極の拍動周期ごとにピーク抽出する
+        result = []
+        for divided_data in data.from_beat_cycles(peak_index, base_ch):
+            peak = detect_peak_neg(divided_data)
+            times, remove_ch = remove_undetected_ch_from64ch(data, peak)
+            grad = Gradient(Solver(times[0], remove_ch, electrode.ele_dis, mesh_num))
+            buf: io.BytesIO = grad.draw2d(contour, isQuiver, dpi=dpi, cmap=cmap, isBuf=isBuf)
+
+            if isBuf:
+                result.append(buf)
+            else:
+                result.append(grad)
+        if isBuf:
+            # list[BytesIO]を渡してもlist[FigImage]にキャストされる
+            return VideoMEA(result)
+        else:
+            return result
+
+    else:
+        grads = Gradients(data, peak_index, electrode.ele_dis, mesh_num)
+        buf_list = grads.draw_2d(contour, isQuiver, dpi=dpi, cmap=cmap, isBuf=isBuf)
+
+        if isBuf:
+            return VideoMEA(buf_list)
+        else:
+            return grads.gradients
+
+
+def draw_3d(
+    data: MEA,
+    electrode: Electrode,
+    peak_index: Peaks64,
+    mesh_num=100,
+    xlabel="X (μm)",
+    ylabel="Y (μm)",
+    clabel="Δt (ms)",
+    dpi=300,
+    isBuf=False,
+) -> VideoMEA | Gradients:
+    """
+    3Dカラーマップ描画
+    """
+    grads = Gradients(data, peak_index, electrode.ele_dis, mesh_num)
+    buf_list = grads.draw_3d(xlabel, ylabel, clabel, dpi, isBuf=isBuf)
+
+    if isBuf:
+        return VideoMEA(buf_list)
+    else:
+        return grads
+
+
+def draw_line_conduction_map(
+    data: MEA,
+    electrode: Electrode,
+    peak_index: Peaks64,
+    amc_chs: list[int],
+    base_ch: int | None = None,
+    isLoop=True,
+    dpi=300,
+    isBuf=False,
+) -> VideoMEA | None:
+    """
+    ライン状心筋細胞ネットワークのカラーマップ描画
+    """
+    if base_ch:
+        # 基準電極が指定されていたらその電極の拍動周期ごとにピーク抽出する
+        if base_ch not in amc_chs:
+            raise ValueError("基準電極はAMC内の電極から選択してください")
+
+        result = []
+        for divided_data in data.from_beat_cycles(peak_index, base_ch):
+            peak = detect_peak_neg(divided_data)
+            times, remove_ch_index = remove_undetected_ch(divided_data, peak, amc_chs)
+            result.append(
+                draw_line(
+                    times[0],
+                    amc_chs,
+                    remove_ch_index,
+                    electrode,
+                    isLoop,
+                    dpi,
+                    isBuf=isBuf,
+                )
+            )
+        if isBuf:
+            return VideoMEA(result)
+    else:
+        buf_list = draw_line_conduction(
+            data, electrode, peak_index, amc_chs, isLoop, dpi, isBuf=isBuf
+        )
+
+        if isBuf:
+            return VideoMEA(buf_list)

--- a/pyMEA/presentation/plot/plot.py
+++ b/pyMEA/presentation/plot/plot.py
@@ -1,4 +1,3 @@
-import statistics
 from typing import List
 
 import matplotlib.pyplot as plt
@@ -7,9 +6,10 @@ from matplotlib.collections import LineCollection
 from numpy import ndarray
 
 from pyMEA.domain.model.Electrode import Electrode
-from pyMEA.presentation.video import FigImage
-from pyMEA.domain.model.peak_model import Peaks64
 from pyMEA.domain.model.MEA import MEA
+from pyMEA.domain.model.peak_model import Peaks64
+from pyMEA.domain.service.peak_times import remove_undetected_ch
+from pyMEA.presentation.FigImage import FigImage
 from pyMEA.presentation.output import output_buf
 
 circuit_eles = [
@@ -262,26 +262,3 @@ def linear_interpolation_path(
     )
 
     return x_fine, y_fine, t_fine
-
-
-def remove_undetected_ch(data: MEA, peak_index: Peaks64, chs: list[int]):
-    # ピークの時刻 (s)を取得
-    time = [data[0][peak_index[ch]] for ch in chs]
-
-    # 各電極の取得ピーク数の最頻値以外の電極は削除
-    peaks = [len(peak_index[ch]) for ch in chs]
-    remove_ch_index = []
-    for i in range(len(time)):
-        if len(time[i]) != statistics.mode(peaks):
-            remove_ch_index.append(i)
-
-    # ピークを正しく検出できていないchのデータを削除
-    for ch in sorted(remove_ch_index, reverse=True):
-        time.pop(ch)
-    print("弾いた電極番号: ", np.array(remove_ch_index))
-
-    times = []
-    for j in range(len(time[0])):
-        times.append([time[i][j] for i in range(len(time))])
-
-    return np.array(times), remove_ch_index

--- a/pyMEA/presentation/plot/waveform.py
+++ b/pyMEA/presentation/plot/waveform.py
@@ -1,0 +1,184 @@
+"""波形描画 (全電極・単一電極・ピーク重畳・スペクトラム)。
+
+FigMEAの同名メソッドから呼び出される実装本体。
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.signal import welch
+
+from pyMEA.constants import ELECTRODE_GRID_SIZE
+from pyMEA.domain.model.MEA import MEA
+from pyMEA.domain.model.peak_model import Peaks64
+from pyMEA.presentation.output import channel, output_buf
+from pyMEA.presentation.plot.color import normalize_color
+
+
+@channel
+@output_buf
+def plot_spectrum(
+    data: MEA, ch: int, max_freq=500, nperseg=2048, figsize=(10, 4), dpi=100, isBuf=False
+):
+    """
+    与えられた信号のスペクトルをプロットする関数
+    - FFTの振幅スペクトル
+    """
+    N = len(data[ch])
+
+    # === FFT ===
+    fft_vals = np.fft.rfft(data[ch])
+    fft_freq = np.fft.rfftfreq(N, 1 / data.SAMPLING_RATE)
+    amplitude = np.abs(fft_vals) / N
+
+    # === Welch ===
+    f, Pxx = welch(data[ch], fs=data.SAMPLING_RATE, nperseg=nperseg)
+
+    # === プロット ===
+    plt.figure(figsize=figsize, dpi=dpi)
+
+    # FFT
+    plt.plot(fft_freq, amplitude)
+    plt.xlim(0, max_freq)
+    plt.xticks(np.arange(0, max_freq + 50, 50))
+    plt.xlabel("Frequency [Hz]")
+    plt.ylabel("Amplitude")
+    plt.grid()
+
+    plt.tight_layout()
+
+
+@output_buf
+def show_all(
+    data: MEA,
+    start=None,
+    end=5,
+    volt_min=-200,
+    volt_max=200,
+    figsize=(8, 8),
+    dpi=300,
+    color: list[str] | list[list[float]] = None,
+    isBuf=False,
+):
+    """
+    64電極すべての波形を描画する
+    """
+    # 時間の設定がない場合はデータの最初から5秒間をプロットする。
+    if start is None:
+        start = data.start
+    if end is None:
+        end = start + 5
+
+    # 読み込み開始時間が0ではないときズレが生じるため差を取っている
+    start_frame = int(abs(data.start - start) * data.SAMPLING_RATE)
+    end_frame = int(abs(data.start - end) * data.SAMPLING_RATE)
+
+    x = data.array[0][start_frame:end_frame]
+
+    color = normalize_color(color)
+
+    fig, axes = plt.subplots(
+        ELECTRODE_GRID_SIZE, ELECTRODE_GRID_SIZE, figsize=figsize, dpi=dpi
+    )
+    color_index = 0
+    for i, ax in enumerate(axes.flat):
+        if color is None:
+            # 配色指定あり
+            ax.plot(x, data.array[i + 1][start_frame:end_frame])
+        else:
+            # 配色指定なし
+            ax.plot(
+                x,
+                data.array[i + 1][start_frame:end_frame],
+                color=color[color_index],
+            )
+            color_index += 1
+            if color_index >= len(color):
+                color_index = 0
+        ax.set_ylim(volt_min, volt_max)
+
+
+@channel
+@output_buf
+def show_single(
+    data: MEA,
+    ch: int,
+    start: int,
+    end: int,
+    volt_min=-200,
+    volt_max=200,
+    figsize=(8, 2),
+    dpi=None,
+    xlabel="Time (s)",
+    ylabel="Voltage (μV)",
+    color: str = None,
+    isBuf=False,
+):
+    """
+    1電極の波形を描画する
+    """
+    # 読み込み開始時間が0ではないときズレが生じるため差を取っている
+    start_frame = int(abs(data.start - start) * data.SAMPLING_RATE)
+    end_frame = int(abs(data.start - end) * data.SAMPLING_RATE)
+
+    plt.figure(figsize=figsize, dpi=dpi)
+    plt.plot(
+        data.array[0][start_frame:end_frame],
+        data.array[ch][start_frame:end_frame],
+        color=color,
+    )
+    plt.xlim(start, end)
+    plt.ylim(volt_min, volt_max)
+    plt.xlabel(xlabel)
+    plt.ylabel(ylabel)
+
+
+@channel
+@output_buf
+def plot_peaks(
+    data: MEA,
+    ch: int,
+    *peak_indexes: Peaks64,
+    start: int,
+    end: int,
+    volt_min=-200,
+    volt_max=200,
+    figsize=(8, 2),
+    dpi=None,
+    xlabel="Time (s)",
+    ylabel="Voltage (μV)",
+    color: str = None,
+    peak_color: list[str] | list[list[float]] = None,
+    isBuf=False,
+):
+    """
+    1電極の波形とピークの位置をプロット
+    """
+    # 読み込み開始時間が0ではないときズレが生じるため差を取っている
+    start_frame = int(abs(data.start - start) * data.SAMPLING_RATE)
+    end_frame = int(abs(data.start - end) * data.SAMPLING_RATE)
+
+    # 波形データのプロット
+    plt.figure(figsize=figsize, dpi=dpi)
+    x, y = (
+        data.array[0][start_frame:end_frame],
+        data.array[ch][start_frame:end_frame],
+    )
+    plt.plot(x, y, color=color)
+
+    # ピークのプロット
+    peak_color = normalize_color(peak_color, "red")
+    peak_color_index = 0
+    for peak_index in peak_indexes:
+        peaks = peak_index[ch]
+        peaks = peaks[start_frame < peaks]
+        peaks = peaks[peaks < end_frame]
+        plt.plot(x[peaks], y[peaks], ".", color=peak_color[peak_color_index])
+
+        peak_color_index += 1
+        if peak_color_index >= len(peak_color):
+            peak_color_index = 0
+
+    plt.xlim(start, end)
+    plt.ylim(volt_min, volt_max)
+    plt.xlabel(xlabel)
+    plt.ylabel(ylabel)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,4 @@
+import matplotlib
+
+# テスト実行時にGUIウィンドウを開かないようにする
+matplotlib.use("Agg")

--- a/test/src/integration/test_full_workflow.py
+++ b/test/src/integration/test_full_workflow.py
@@ -1,0 +1,73 @@
+"""読み込みから解析・描画までの一連のワークフローを通す統合テスト。
+
+従来の手動実行スクリプト (integration_test_*.py) のpytest版。
+描画は isBuf=True でヘッドレス実行する。
+"""
+
+import unittest
+from test.utils import get_resource_path
+
+from pyMEA import FilterType, detect_peak_all, detect_peak_neg, read_MEA
+from pyMEA.presentation.FigImage import FigImage
+
+
+class TestNeuronWorkflow(unittest.TestCase):
+    """神経データの解析ワークフロー"""
+
+    @classmethod
+    def setUpClass(cls):
+        path = get_resource_path("230615_day2_test_5s_.hed")
+        cls.mea = read_MEA(path.__str__(), 0, 5, 450)
+        cls.neg_peaks = detect_peak_neg(cls.mea.data)
+        cls.all_peaks = detect_peak_all(cls.mea.data)
+
+    def test_読み込みからISI計算まで(self):
+        isi = self.mea.calculator.isi(self.neg_peaks, ch=32)
+        self.assertTrue((isi.values > 0).all())
+        self.assertTrue(0 < isi.mean < 2)
+
+    def test_読み込みから伝導速度計算まで(self):
+        cv = self.mea.calculator.conduction_velocity(self.neg_peaks, 32, 33)
+        self.assertTrue((cv.values > 0).all())
+
+        gv = self.mea.calculator.gradient_velocity(self.neg_peaks)
+        self.assertEqual(len(self.neg_peaks[32]), len(gv))
+
+    def test_読み込みから描画まで(self):
+        self.assertIsInstance(self.mea.fig.showAll(isBuf=True), FigImage)
+        self.assertIsInstance(
+            self.mea.fig.plotPeaks(32, self.neg_peaks, self.all_peaks, isBuf=True),
+            FigImage,
+        )
+
+    def test_変換チェーンの結果でも解析できる(self):
+        sub = self.mea.from_slice(1, 4).init_time()
+        peaks = detect_peak_neg(sub.data)
+        isi = sub.calculator.isi(peaks, ch=32)
+        self.assertEqual(len(peaks[32]) - 1, len(isi))
+
+
+class TestCardioWorkflow(unittest.TestCase):
+    """心筋データの解析ワークフロー (平均波形フィルタ使用)"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.path = get_resource_path("1102_dish3_day10_p210_5sec_.hed")
+
+    def test_平均波形フィルタを通したFPD計算(self):
+        mea = read_MEA(self.path.__str__(), 0, 5, 450, FilterType.CARDIO_AVE_WAVE)
+        neg_peaks = detect_peak_neg(mea.data)
+        fpd = mea.calculator.fpd(neg_peaks, ch=32)
+        # FPDは設定した許容範囲内に収まる
+        for value in fpd.values:
+            self.assertTrue(0.1 < value < 0.4)
+
+    def test_生データのままFPD計算(self):
+        mea = read_MEA(self.path.__str__(), 0, 5, 450)
+        neg_peaks = detect_peak_neg(mea.data)
+        fpd = mea.calculator.fpd(neg_peaks, ch=32)
+        self.assertGreaterEqual(len(fpd), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/src/unit/application/test_PyMEA.py
+++ b/test/src/unit/application/test_PyMEA.py
@@ -1,0 +1,73 @@
+import unittest
+from test.utils import get_resource_path
+
+import numpy as np
+
+from pyMEA import MutableMEA, detect_peak_neg, read_MEA
+
+
+class TestPyMEATransformations(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.path = get_resource_path("230615_day2_test_5s_.hed")
+        cls.mea = read_MEA(cls.path.__str__(), 0, 5, 450)
+
+    def test_from_sliceで切り出した区間の責務クラスが再構築される(self):
+        sliced = self.mea.from_slice(1, 3)
+
+        self.assertEqual(1, sliced.data.start)
+        self.assertEqual(3, sliced.data.end)
+        # fig, calculatorが新しいdataを参照している
+        self.assertIs(sliced.data, sliced.fig.data)
+        self.assertIs(sliced.data, sliced.calculator.data)
+        self.assertIs(self.mea.electrode, sliced.electrode)
+        # 元のインスタンスは変更されない (イミュータブル)
+        self.assertEqual(0, self.mea.data.start)
+        self.assertEqual(5, self.mea.data.end)
+
+    def test_init_timeで時刻が0から始まる(self):
+        sliced = self.mea.from_slice(2, 4).init_time()
+        self.assertEqual(0, sliced.data.start)
+        self.assertAlmostEqual(0, sliced.data.array[0][0])
+
+    def test_down_samplingでサンプリングレートが下がる(self):
+        down = self.mea.down_sampling(100)
+        self.assertEqual(
+            int(self.mea.data.SAMPLING_RATE / 100), down.data.SAMPLING_RATE
+        )
+        self.assertIs(down.data, down.fig.data)
+
+    def test_iirnotch_filterで形状が維持される(self):
+        filtered = self.mea.iirnotch_filter()
+        self.assertEqual(self.mea.data.shape, filtered.data.shape)
+        self.assertIs(filtered.data, filtered.calculator.data)
+
+    def test_from_beat_cyclesで拍動周期ごとに分割される(self):
+        peaks = detect_peak_neg(self.mea.data)
+        beats = self.mea.from_beat_cycles(peaks, base_ch=32)
+
+        self.assertEqual(len(peaks[32]), len(beats))
+        for beat in beats:
+            self.assertIs(beat.data, beat.fig.data)
+            self.assertIs(beat.data, beat.calculator.data)
+
+    def test_算術演算はndarrayに委譲される(self):
+        added = self.mea + 1
+        np.testing.assert_array_equal(self.mea.data.array + 1, added)
+        self.assertEqual(len(self.mea.data.array), len(self.mea))
+
+
+class TestMutableMEA(unittest.TestCase):
+    def test_インスタンス化できる(self):
+        # decode_hedの戻り値アンパックのバグ修正に対する回帰テスト
+        path = get_resource_path("230615_day2_test_5s_.hed")
+        m = MutableMEA(path.__str__(), 0, 5)
+
+        self.assertEqual(10000, m.SAMPLING_RATE)
+        self.assertEqual(2000, m.GAIN)
+        self.assertEqual((65, 50000), m.array.shape)
+        self.assertEqual(5, m.time)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/src/unit/domain/test_abstract_values.py
+++ b/test/src/unit/domain/test_abstract_values.py
@@ -1,0 +1,42 @@
+import unittest
+
+import numpy as np
+
+from pyMEA.domain.value.AbstractValues import AbstractValues
+
+
+class TestAbstractValues(unittest.TestCase):
+    def setUp(self):
+        self.values = AbstractValues(np.array([1.0, 2.0, 3.0, 4.0]))
+
+    def test_統計量を計算できる(self):
+        self.assertAlmostEqual(2.5, self.values.mean)
+        self.assertAlmostEqual(np.std([1, 2, 3, 4]), self.values.std)
+        self.assertAlmostEqual(self.values.std / 4, self.values.se)
+        # STV: 連続差分の絶対値の合計 / (N * sqrt(2))
+        self.assertAlmostEqual(3 / (3 * np.sqrt(2)), self.values.stv)
+        self.assertAlmostEqual(
+            np.std([1, 2, 3, 4]) / 2.5 * 100, self.values.coefficient_of_variation
+        )
+
+    def test_算術演算はndarrayに委譲される(self):
+        np.testing.assert_array_equal(np.array([2.0, 3.0, 4.0, 5.0]), self.values + 1)
+        np.testing.assert_array_equal(np.array([0.0, 1.0, 2.0, 3.0]), self.values - 1)
+        np.testing.assert_array_equal(np.array([2.0, 4.0, 6.0, 8.0]), self.values * 2)
+        np.testing.assert_array_equal(np.array([0.5, 1.0, 1.5, 2.0]), self.values / 2)
+        np.testing.assert_array_equal(np.array([0.0, 1.0, 1.0, 2.0]), self.values // 2)
+
+    def test_比較演算ができる(self):
+        np.testing.assert_array_equal([False, False, True, True], self.values > 2)
+        np.testing.assert_array_equal([True, True, False, False], self.values <= 2)
+        self.assertEqual(self.values, AbstractValues(np.array([1.0, 2.0, 3.0, 4.0])))
+        # AbstractValues以外との __eq__ はFalseになる (__ne__は要素ごとの配列を返す仕様)
+        self.assertFalse(self.values == "not values")
+
+    def test_インデックスアクセスと長さを取得できる(self):
+        self.assertEqual(4, len(self.values))
+        self.assertEqual(3.0, self.values[2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/src/unit/domain/test_burst.py
+++ b/test/src/unit/domain/test_burst.py
@@ -1,0 +1,37 @@
+import unittest
+from test.utils import get_resource_path
+
+import numpy as np
+
+from pyMEA import detect_peak_neg, read_MEA
+from pyMEA.domain.service.burst import peak_flatten, sbf_detection, sbf_single
+
+
+class TestBurst(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = get_resource_path("230615_day2_test_5s_.hed")
+        cls.mea = read_MEA(path.__str__(), 1, 2, 450)
+        cls.peak_index = detect_peak_neg(cls.mea.data)
+
+    def test_全電極のピーク時刻を一次元配列にまとめられる(self):
+        flat = peak_flatten(self.mea.data, self.peak_index)
+
+        total_peaks = sum(len(self.peak_index[ch]) for ch in range(1, 65))
+        self.assertEqual(total_peaks, len(flat))
+        self.assertIsInstance(flat, np.ndarray)
+        # 全て読み込み時間の範囲内
+        self.assertTrue((flat >= 1).all())
+        self.assertTrue((flat <= 2).all())
+
+    def test_同期バースト発火検出が実行できる(self):
+        result = sbf_detection(self.mea.data, self.peak_index)
+        self.assertIsInstance(result, list)
+
+    def test_1電極バースト発火検出が実行できる(self):
+        result = sbf_single(self.mea.data, self.peak_index, ch=32)
+        self.assertIsInstance(result, list)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/src/unit/domain/test_electrode.py
+++ b/test/src/unit/domain/test_electrode.py
@@ -1,0 +1,64 @@
+import unittest
+
+import numpy as np
+
+from pyMEA.domain.model.Electrode import Electrode, get_mesh
+
+
+class TestGetMesh(unittest.TestCase):
+    def test_メッシュの形状が指定どおりになる(self):
+        for mesh_num in (8, 100):
+            xx, yy = get_mesh(450, mesh_num)
+            self.assertEqual((mesh_num, mesh_num), xx.shape)
+            self.assertEqual((mesh_num, mesh_num), yy.shape)
+
+    def test_メッシュの範囲が電極エリア全体になる(self):
+        ele_dis = 450
+        xx, yy = get_mesh(ele_dis, 8)
+        self.assertEqual(0, xx.min())
+        self.assertEqual(ele_dis * 7, xx.max())
+        self.assertEqual(0, yy.min())
+        self.assertEqual(ele_dis * 7, yy.max())
+
+    def test_y座標は電極番号順に上から下へ並ぶ(self):
+        ele_dis = 450
+        _, yy = get_mesh(ele_dis, 8)
+        # 電極1 (左上) のy座標が最大、電極57 (左下) のy座標が0
+        self.assertEqual(ele_dis * 7, yy[0][0])
+        self.assertEqual(0, yy[7][0])
+
+
+class TestElectrode(unittest.TestCase):
+    def setUp(self):
+        self.electrode = Electrode(450)
+
+    def test_電極メッシュは8x8になる(self):
+        xx, yy = self.electrode.get_electrode_mesh
+        self.assertEqual((8, 8), xx.shape)
+        self.assertEqual((8, 8), yy.shape)
+
+    def test_電極座標を取得できる(self):
+        # 電極1は左上 (x=0, y=ele_dis*7)
+        x, y = self.electrode.get_coordinate(1)
+        self.assertEqual(0, x)
+        self.assertEqual(450 * 7, y)
+
+        # 電極64は右下 (x=ele_dis*7, y=0)
+        x, y = self.electrode.get_coordinate(64)
+        self.assertEqual(450 * 7, x)
+        self.assertEqual(0, y)
+
+    def test_電極間の座標距離が電極間距離と一致する(self):
+        x1, y1 = self.electrode.get_coordinate(1)
+        x2, y2 = self.electrode.get_coordinate(2)
+        self.assertAlmostEqual(450, np.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2))
+
+    def test_範囲外の電極番号はValueErrorになる(self):
+        with self.assertRaises(ValueError):
+            self.electrode.get_coordinate(0)
+        with self.assertRaises(ValueError):
+            self.electrode.get_coordinate(65)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/src/unit/domain/test_filter_services.py
+++ b/test/src/unit/domain/test_filter_services.py
@@ -1,0 +1,43 @@
+import unittest
+from test.utils import get_resource_path
+
+from pyMEA import detect_peak_neg, read_MEA
+from pyMEA.domain.service.CardioAveWave import calc_64_ave_waves
+from pyMEA.domain.service.FilterMEA import filter_by_moving_average
+
+
+class TestFilterMEA(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = get_resource_path("230615_day2_test_5s_.hed")
+        cls.mea = read_MEA(path.__str__(), 0, 5, 450)
+
+    def test_移動平均フィルタ後も形状が維持される(self):
+        filtered = filter_by_moving_average(self.mea.data)
+        self.assertEqual(self.mea.data.shape, filtered.shape)
+
+    def test_フィルタは元データを変更しない(self):
+        before = self.mea.data.array.copy()
+        filter_by_moving_average(self.mea.data)
+        self.assertTrue((before == self.mea.data.array).all())
+
+
+class TestCardioAveWave(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = get_resource_path("1102_dish3_day10_p210_5sec_.hed")
+        cls.mea = read_MEA(path.__str__(), 0, 5, 450)
+        cls.neg_peaks = detect_peak_neg(cls.mea.data)
+
+    def test_平均波形は指定時間幅の形状になる(self):
+        front, back = 0.05, 0.3
+        ave_waves = calc_64_ave_waves(self.mea.data, self.neg_peaks, front, back)
+
+        expected_frames = int(self.mea.data.SAMPLING_RATE * (front + back))
+        self.assertEqual((65, expected_frames), ave_waves.shape)
+        # 時間データは0から始まる
+        self.assertEqual(0, ave_waves[0][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/src/unit/domain/test_peak_times.py
+++ b/test/src/unit/domain/test_peak_times.py
@@ -1,0 +1,47 @@
+import unittest
+from test.utils import get_resource_path
+
+from pyMEA import detect_peak_neg, read_MEA
+from pyMEA.domain.service.peak_times import (
+    remove_undetected_ch,
+    remove_undetected_ch_from64ch,
+)
+
+
+class TestPeakTimes(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = get_resource_path("230615_day2_test_5s_.hed")
+        cls.mea = read_MEA(path.__str__(), 1, 2, 450)
+        cls.peak_index = detect_peak_neg(cls.mea.data)
+
+    def test_64電極のピーク時刻行列を取得できる(self):
+        times, remove_ch = remove_undetected_ch_from64ch(self.mea.data, self.peak_index)
+
+        # 残った電極数 + 除去電極数 = 64
+        self.assertEqual(64, times.shape[1] + len(remove_ch))
+        # ピーク時刻は読み込み時間の範囲内
+        self.assertTrue((times >= 1).all())
+        self.assertTrue((times <= 2).all())
+
+    def test_指定電極のみのピーク時刻行列を取得できる(self):
+        chs = [31, 32, 33, 34]
+        times, remove_ch_index = remove_undetected_ch(self.mea.data, self.peak_index, chs)
+
+        self.assertEqual(len(chs), times.shape[1] + len(remove_ch_index))
+        # 除去インデックスはchsのインデックス範囲内
+        for i in remove_ch_index:
+            self.assertTrue(0 <= i < len(chs))
+
+    def test_64電極版は汎用版と同じ結果を返す(self):
+        times64, remove64 = remove_undetected_ch_from64ch(self.mea.data, self.peak_index)
+        times, remove = remove_undetected_ch(
+            self.mea.data, self.peak_index, list(range(1, 65))
+        )
+
+        self.assertEqual(remove64, remove)
+        self.assertTrue((times64 == times).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/src/unit/domain/test_solver.py
+++ b/test/src/unit/domain/test_solver.py
@@ -1,0 +1,64 @@
+import unittest
+from test.utils import get_resource_path
+
+import numpy as np
+
+from pyMEA import detect_peak_neg, read_MEA
+from pyMEA.domain.service.gradient.Gradient import grad_model, grad_velocity
+from pyMEA.domain.service.gradient.Solver import Solver, model
+from pyMEA.domain.service.peak_times import remove_undetected_ch_from64ch
+
+
+class TestSolver(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = get_resource_path("230615_day2_test_5s_.hed")
+        cls.mea = read_MEA(path.__str__(), 1, 2, 450)
+        peak_index = detect_peak_neg(cls.mea.data)
+        cls.times, cls.remove_ch = remove_undetected_ch_from64ch(
+            cls.mea.data, peak_index
+        )
+
+    def test_フィッティング結果が正しい形状になる(self):
+        solver = Solver(self.times[0], self.remove_ch, 450, 100)
+
+        # 3次多項式の係数は10個
+        self.assertEqual(10, len(solver.popt))
+        # 決定係数が計算されている
+        self.assertTrue(0 < solver.r2 <= 1)
+        # メッシュはmesh_num x mesh_num
+        self.assertEqual((100, 100), solver.xx.shape)
+        self.assertEqual((100, 100), solver.yy.shape)
+        self.assertEqual(100 * 100, len(solver.z))
+
+    def test_zは発火起点が0msに正規化される(self):
+        solver = Solver(self.times[0], self.remove_ch, 450, 50)
+        self.assertAlmostEqual(0, solver.z.min())
+
+    def test_solverの配列はイミュータブル(self):
+        solver = Solver(self.times[0], self.remove_ch, 450, 50)
+        with self.assertRaises(ValueError):
+            solver.xx[0][0] = 999
+
+    def test_model式が定数項のみの場合は定数を返す(self):
+        xx, yy = np.meshgrid(np.linspace(0, 1, 4), np.linspace(0, 1, 4))
+        z = model((xx, yy), 5, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        self.assertTrue((z == 5).all())
+
+    def test_grad_modelは線形項の係数を勾配として返す(self):
+        xx, yy = np.meshgrid(np.linspace(0, 1, 4), np.linspace(0, 1, 4))
+        # z = 2x + 3y -> grad_x = 2, grad_y = 3
+        grad_x, grad_y = grad_model((xx, yy), 0, 2, 3, 0, 0, 0, 0, 0, 0, 0)
+        self.assertTrue((grad_x == 2).all())
+        self.assertTrue((grad_y == 3).all())
+
+    def test_grad_velocityは勾配の逆数方向の速度を返す(self):
+        grad_x = np.array([1.0])
+        grad_y = np.array([0.0])
+        vx, vy = grad_velocity(grad_x, grad_y)
+        self.assertAlmostEqual(1.0, vx[0])
+        self.assertAlmostEqual(0.0, vy[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/src/unit/domain/test_validators.py
+++ b/test/src/unit/domain/test_validators.py
@@ -1,0 +1,64 @@
+import unittest
+
+from pyMEA.domain.validators import ch_validator, get_argument, time_validator
+
+
+@ch_validator
+def func_with_ch(ch: int):
+    return ch
+
+
+@time_validator
+def func_with_time(start: int, end: int):
+    return start, end
+
+
+def sample_func(a, b, c=3):
+    return a + b + c
+
+
+class TestChValidator(unittest.TestCase):
+    def test_有効な電極番号はそのまま実行される(self):
+        for ch in (1, 32, 64):
+            self.assertEqual(ch, func_with_ch(ch))
+
+    def test_範囲外の電極番号はValueErrorになる(self):
+        for ch in (0, 65, -1, 100):
+            with self.assertRaises(ValueError) as context:
+                func_with_ch(ch)
+            self.assertEqual(
+                "chは1-64の整数で入力してください", str(context.exception)
+            )
+
+
+class TestTimeValidator(unittest.TestCase):
+    def test_有効な時間範囲はそのまま実行される(self):
+        self.assertEqual((0, 5), func_with_time(0, 5))
+        self.assertEqual((1, 1), func_with_time(1, 1))
+
+    def test_負の時間はValueErrorになる(self):
+        with self.assertRaises(ValueError):
+            func_with_time(-1, 5)
+        with self.assertRaises(ValueError):
+            func_with_time(0, -5)
+
+    def test_startがendより大きい場合はValueErrorになる(self):
+        with self.assertRaises(ValueError):
+            func_with_time(5, 1)
+
+
+class TestGetArgument(unittest.TestCase):
+    def test_キーワード引数から値を取得できる(self):
+        self.assertEqual(2, get_argument(sample_func, (), {"b": 2}, "b"))
+
+    def test_位置引数から値を取得できる(self):
+        self.assertEqual(1, get_argument(sample_func, (1, 2), {}, "a"))
+        self.assertEqual(2, get_argument(sample_func, (1, 2), {}, "b"))
+
+    def test_存在しない引数はNoneを返す(self):
+        self.assertIsNone(get_argument(sample_func, (1,), {}, "z"))
+        self.assertIsNone(get_argument(sample_func, (1,), {}, "c"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/src/unit/presentation/test_color_and_video.py
+++ b/test/src/unit/presentation/test_color_and_video.py
@@ -1,0 +1,88 @@
+import tempfile
+import unittest
+from pathlib import Path
+from test.utils import get_resource_path
+
+from pyMEA import read_MEA
+from pyMEA.presentation.plot.color import normalize_color
+from pyMEA.presentation.plot.pointcare_plot import autocorrelation, normalize_data
+
+
+class TestNormalizeColor(unittest.TestCase):
+    def test_Noneはデフォルトカラーのリストになる(self):
+        self.assertEqual([None], normalize_color(None))
+        self.assertEqual(["red"], normalize_color(None, "red"))
+
+    def test_文字列は単一要素リストになる(self):
+        self.assertEqual(["blue"], normalize_color("blue"))
+
+    def test_RGB値1セットは入れ子リストになる(self):
+        self.assertEqual([[0.1, 0.2, 0.3]], normalize_color([0.1, 0.2, 0.3]))
+
+    def test_リストはそのまま返る(self):
+        self.assertEqual(["r", "g"], normalize_color(["r", "g"]))
+        self.assertEqual([[0.1, 0.2], [0.3, 0.4]], normalize_color([[0.1, 0.2], [0.3, 0.4]]))
+
+    def test_不正な型はTypeErrorになる(self):
+        with self.assertRaises(TypeError):
+            normalize_color(123)
+
+
+class TestPointcareUtils(unittest.TestCase):
+    def test_正規化で指定範囲に収まる(self):
+        normalized = normalize_data([1.0, 2.0, 3.0])
+        self.assertAlmostEqual(-1, normalized.min())
+        self.assertAlmostEqual(1, normalized.max())
+
+    def test_自己相関係数が計算できる(self):
+        import numpy as np
+
+        # 一定値からの線形増加データはラグ0で正の自己相関を持つ
+        data = np.sin(np.linspace(0, 4 * np.pi, 100))
+        r = autocorrelation(data, 0)
+        self.assertTrue(-1 <= r <= 1)
+
+
+class TestVideoMEA(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = get_resource_path("230615_day2_test_5s_.hed")
+        cls.mea = read_MEA(path.__str__(), 1, 2, 450)
+
+    def test_GIFを保存できる(self):
+        from pyMEA import detect_peak_neg
+
+        peaks = detect_peak_neg(self.mea.data)
+        video = self.mea.fig.draw_2d(peaks, mesh_num=10, dpi=50, isBuf=True)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gif_path = Path(tmpdir) / "output.gif"
+            video.save_gif(str(gif_path))
+            self.assertTrue(gif_path.exists())
+            self.assertGreater(gif_path.stat().st_size, 0)
+
+    def test_拡張子が不正な場合はValueErrorになる(self):
+        from pyMEA import detect_peak_neg
+
+        peaks = detect_peak_neg(self.mea.data)
+        video = self.mea.fig.draw_2d(peaks, mesh_num=10, dpi=50, isBuf=True)
+
+        with self.assertRaises(ValueError):
+            video.save_gif("./output.png")
+        with self.assertRaises(ValueError):
+            video.save_mp4("./output.gif")
+
+    def test_FigImageを画像ファイルに保存できる(self):
+        img = self.mea.fig.showSingle(32, isBuf=True)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            png_path = Path(tmpdir) / "output.png"
+            img.save(str(png_path))
+            self.assertTrue(png_path.exists())
+
+            with self.assertRaises(ValueError):
+                img.save(str(Path(tmpdir) / "output.bmp"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/src/unit/presentation/test_fig_output.py
+++ b/test/src/unit/presentation/test_fig_output.py
@@ -1,0 +1,51 @@
+import unittest
+from test.utils import get_resource_path
+
+from pyMEA import detect_peak_neg, read_MEA
+from pyMEA.presentation.FigImage import FigImage
+from pyMEA.presentation.video import VideoMEA
+
+
+class TestFigMEABufferOutput(unittest.TestCase):
+    """全描画メソッドが isBuf=True で FigImage / VideoMEA を返すことを保証する。"""
+
+    @classmethod
+    def setUpClass(cls):
+        path = get_resource_path("230615_day2_test_5s_.hed")
+        cls.mea = read_MEA(path.__str__(), 1, 2, 450)
+        cls.peaks = detect_peak_neg(cls.mea.data)
+
+    def test_波形描画はFigImageを返す(self):
+        self.assertIsInstance(self.mea.fig.showAll(isBuf=True), FigImage)
+        self.assertIsInstance(self.mea.fig.showSingle(32, isBuf=True), FigImage)
+        self.assertIsInstance(
+            self.mea.fig.plotPeaks(32, self.peaks, isBuf=True), FigImage
+        )
+        self.assertIsInstance(self.mea.fig.plot_spectrum(32, isBuf=True), FigImage)
+        self.assertIsInstance(
+            self.mea.fig.showDetection([31, 32, 33], isBuf=True), FigImage
+        )
+
+    def test_ラスタプロットとヒストグラムはFigImageを返す(self):
+        self.assertIsInstance(
+            self.mea.fig.raster_plot(self.peaks, [31, 32, 33], isBuf=True), FigImage
+        )
+        self.assertIsInstance(
+            self.mea.fig.mkHist(self.peaks, [31, 32, 33], isBuf=True), FigImage
+        )
+
+    def test_カラーマップはVideoMEAを返す(self):
+        video = self.mea.fig.draw_2d(self.peaks, mesh_num=20, isBuf=True)
+        self.assertIsInstance(video, VideoMEA)
+        self.assertEqual(len(self.peaks[32]), len(video))
+
+        video3d = self.mea.fig.draw_3d(self.peaks, mesh_num=20, isBuf=True)
+        self.assertIsInstance(video3d, VideoMEA)
+
+    def test_値オブジェクトの描画はFigImageを返す(self):
+        isi = self.mea.calculator.isi(self.peaks, ch=32)
+        self.assertIsInstance(isi.show(isBuf=True), FigImage)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

スタックPRのマージ時に #44 (Phase3) と #45 (Phase4) が main ではなく中間ブランチ（`refactor/phase2-layers` / `refactor/phase3-dedup`）へマージされ、**main に Phase3・Phase4 の内容が反映されていなかった**ため、その復旧用PRです。

main には既に Phase1+Phase2 があるので、本PRの差分は不足分の **Phase3 + Phase4** のみです。

## 含まれる変更

| コミット | 内容 |
|---|---|
| `1106248` | **Phase3**: 責務分割と重複コードの解消（get_mesh一本化、FigMEA分割、`colormap.py`/`waveform.py`/`color.py` 抽出 等） |
| `19044ba` | **Phase4**: ドメイン層・presentation層のユニットテスト＋統合テスト追加（テスト数 25→97、カバレッジ88%） |
| `829a4e1` | docs: 各種mdのパッケージ構成・モジュールパスをDDDレイヤー構成に更新 |
| `e2c541e` | docs: READMEサンプルコードの誤り修正 |

差分: 32ファイル / +1304 −437行。`origin/main` に対しコンフリクトなし。

## 検証

- `pytest test/` → **97 passed**（カバレッジ88%）。
- リファクタ前後の出力一致を実データ（心筋 `230615_day2_test_5s_.hed` / 神経 `1102_dish3_day10_p210_5sec_.hed`）で検証済み。ピーク抽出・ISI・FPD・伝導速度・Gradients・calc_velocity・全描画メソッド・`draw_line_conduction`（base_ch分岐含む）・バースト解析・フィルタ・各種変換・remove_artifact・GIF生成が、数値ビット単位/画像バイト単位で完全一致。
- 公開API（`__all__`）の名前・シグネチャは不変（`test_public_api.py` がガード）。
- 検出した差分はいずれも意図的なバグ修正（`MutableMEA` のmain既存バグ修正 等）で退行なし。

## 経緯メモ

#44/#45 は GitHub 上「Merged」表示だが、中間 head ブランチが削除されず短時間で連続マージしたためベースのリターゲットが間に合わず、変更が main へ到達していなかった。本PRで Phase3+Phase4 を main に取り込む。マージ後は中間ブランチ（`refactor/phase2-layers`, `refactor/phase3-dedup`）は削除可。
