### PR TITLE
fix: Windows環境でdevcontainerが起動しない問題を修正 (mounts一時無効化)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
   // Use 'postCreateCommand' to run commands after the container is created.
 "postCreateCommand": "curl -fsSL https://claude.ai/install.sh | bash && pip3 install --user -r requirements.txt && pip3 install --user -e .",
 "mounts": [
-  "source=${localWorkspaceFolder}/data,target=/data,type=bind,consistency=cached"
+  "source=${localEnv:MEA_DATA_PATH:${localWorkspaceFolder}/data},target=/data,type=bind,consistency=cached"
 ],
 "customizations": {
 	"vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,10 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
+  // initializeCommand: ホスト側にbindマウント用ディレクトリを作成する。
+  // Mac/Linux: sh で mkdir を実行。Windows: sh が無くても || exit 0 でエラーを吸収。
+  // Windows ユーザーは MEA_DATA_PATH に既存ディレクトリを設定すること。
+"initializeCommand": "mkdir -p \"${localEnv:MEA_DATA_PATH:/tmp/mea_data}\" 2>/dev/null || exit 0",
 "postCreateCommand": "curl -fsSL https://claude.ai/install.sh | bash && pip3 install --user -r requirements.txt && pip3 install --user -e .",
 "mounts": [
   "source=${localEnv:MEA_DATA_PATH:/tmp/mea_data},target=/data,type=bind,consistency=cached"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,6 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-"initializeCommand": "sh .devcontainer/init.sh",
 "postCreateCommand": "curl -fsSL https://claude.ai/install.sh | bash && pip3 install --user -r requirements.txt && pip3 install --user -e .",
 "mounts": [
   "source=${localEnv:MEA_DATA_PATH:/tmp/mea_data},target=/data,type=bind,consistency=cached"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,13 +14,9 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  // initializeCommand: ホスト側にbindマウント用ディレクトリを作成する。
-  // Mac/Linux: sh で mkdir を実行。Windows: sh が無くても || exit 0 でエラーを吸収。
-  // Windows ユーザーは MEA_DATA_PATH に既存ディレクトリを設定すること。
-"initializeCommand": "mkdir -p \"${localEnv:MEA_DATA_PATH:/tmp/mea_data}\" 2>/dev/null || exit 0",
 "postCreateCommand": "curl -fsSL https://claude.ai/install.sh | bash && pip3 install --user -r requirements.txt && pip3 install --user -e .",
 "mounts": [
-  "source=${localEnv:MEA_DATA_PATH:/tmp/mea_data},target=/data,type=bind,consistency=cached"
+  "source=${localWorkspaceFolder}/data,target=/data,type=bind,consistency=cached"
 ],
 "customizations": {
 	"vscode": {

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-mkdir -p "${MEA_DATA_PATH:-/tmp/mea_data}" 2>/dev/null || true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-data/
+data/*
+!data/.gitkeep
 .DS_Store
 __pycache__
 pyMEA.egg-info


### PR DESCRIPTION
## Summary

- `initializeCommand` に Windows非対応の `sh` コマンドが含まれていた問題を修正
- `init.sh` を削除（Docker Desktopがソースディレクトリを自動作成するため不要）
- バインドマウントのデフォルトパスを `${localEnv:MEA_DATA_PATH:/data}` から `data/` ディレクトリ基準に変更
- devcontainer CLI がネストした変数置換 (`${localEnv:VAR:${localWorkspaceFolder}/...}`) を展開できない問題が発覚したため、`mounts` を一時的にコメントアウト（別PRで対策予定）

## 変更内容

| コミット | 内容 |
|---|---|
| `0064d32` | Windows対応: `initializeCommand` から `sh` を除去、`init.sh` 削除 |
| `ea224a2` | `initializeCommand` でディレクトリ作成をインライン化 |
| `e286c32` | マウント先を `data/` ディレクトリに変更 |
| `3f82d4f` | `MEA_DATA_PATH` 未設定時のデフォルトパスを修正 |
| `f51e71d` | `mounts` を一時コメントアウト（CLIの変数展開制限による暫定対応） |

## Test plan

- [ ] Windows 環境で devcontainer を開いて正常に起動することを確認
- [ ] Mac/Linux 環境で devcontainer が引き続き正常に動作することを確認
- [ ] `/data` のマウントが不要な場合でもコンテナが起動することを確認

## 今後の対応

バインドマウント (`mounts`) の恒久的な対策は別PRで実施予定。