### PR TITLE
feat(mea2npz): v1.0.0 — パス引用符対応とデータ長表示の整合

### DIFF
--- a/.github/workflows/release-mea2npz.yml
+++ b/.github/workflows/release-mea2npz.yml
@@ -38,8 +38,10 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: "0"
         run: |
+          # タグ mea2npz-v1.0.0 → バージョン 1.0.0(プレフィックスを剥がす)
+          version="${GITHUB_REF_NAME#mea2npz-v}"
           out="mea2npz-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}"
-          go build -ldflags "-s -w -X github.com/kkito0726/MEA_modules/tools/mea2npz/internal/interface/cli.Version=${GITHUB_REF_NAME}" -o "$out" ./cmd/mea2npz
+          go build -ldflags "-s -w -X github.com/kkito0726/MEA_modules/tools/mea2npz/internal/interface/cli.Version=${version}" -o "$out" ./cmd/mea2npz
           echo "ASSET=$out" >> "$GITHUB_ENV"
 
       - name: Upload to Release

--- a/tools/mea2npz/README.md
+++ b/tools/mea2npz/README.md
@@ -35,7 +35,7 @@ mea2npz                                     # 引数なしで対話モード
 
 ```
 $ mea2npz -version
-mea2npz 0.1.0
+mea2npz 1.0.0
 Copyright (C) 2026 kkito0726
 License: MIT
 Written by kkito0726.
@@ -69,7 +69,7 @@ mea2npz data.npz                    # .npz の情報を表形式で表示(変換
 
 ### .npz の情報表示
 
-`.npz` を渡すと、電極間距離・サンプリングレート・GAIN・計測時間を表で確認できます（pyMEA 生成の `.npz` も可）。
+`.npz` を渡すと、電極間距離・サンプリングレート・GAIN・データ長を表で確認できます（pyMEA 生成の `.npz` も可）。
 
 ```
 $ mea2npz data.npz
@@ -80,7 +80,7 @@ $ mea2npz data.npz
 │ 電極間距離 (um)         │ 450   │
 │ サンプリングレート (Hz) │ 5000  │
 │ GAIN                    │ 50000 │
-│ 計測時間 (s)            │ 1     │
+│ データ長 (s)            │ 1     │
 │ dtype                   │ int16 │
 └─────────────────────────┴───────┘
 ```
@@ -140,7 +140,7 @@ sequenceDiagram
     IR->>FS: .npz の ZIP からスカラ.npy のみ読込<br/>(voltages は読まない)
     IR-->>UC: MeasurementInfo
     UC-->>CLI: MeasurementInfo
-    CLI-->>U: 電極間距離/サンプリングレート/GAIN/計測時間 を表で表示
+    CLI-->>U: 電極間距離/サンプリングレート/GAIN/データ長 を表で表示
 ```
 
 ## 開発

--- a/tools/mea2npz/internal/domain/info.go
+++ b/tools/mea2npz/internal/domain/info.go
@@ -11,7 +11,7 @@ type MeasurementInfo struct {
 	Dtype             string
 }
 
-// DurationSec は計測時間(秒) = End - Start を返す。
+// DurationSec はデータ長(秒) = End - Start を返す。
 func (i MeasurementInfo) DurationSec() float64 { return i.End - i.Start }
 
 // MeasurementInfoReader は計測メタ情報の取得元を表すリポジトリポート。

--- a/tools/mea2npz/internal/domain/measurement.go
+++ b/tools/mea2npz/internal/domain/measurement.go
@@ -13,6 +13,20 @@ type Measurement struct {
 	End          float64
 }
 
+// Info は実際に保持している計測区間のメタ情報を返す(表示用)。
+// Start/End は読み込んだ時間窓を反映するため、.npz 保存後の情報表示と一致する。
+func (m Measurement) Info(distance int, dtype Dtype) MeasurementInfo {
+	return MeasurementInfo{
+		SamplingRate:      m.SamplingRate,
+		Gain:              m.Gain,
+		Start:             m.Start,
+		End:               m.End,
+		ElectrodeDistance: distance,
+		HasDistance:       distance > 0,
+		Dtype:             string(dtype),
+	}
+}
+
 // Channels は電極数を返す。
 func (m Measurement) Channels() int { return len(m.Voltages) }
 

--- a/tools/mea2npz/internal/domain/measurement_test.go
+++ b/tools/mea2npz/internal/domain/measurement_test.go
@@ -1,0 +1,37 @@
+package domain
+
+import "testing"
+
+// 時間窓を指定した計測データの Info は、ファイル全体ではなく
+// 実際に保持している区間のデータ長 (End-Start) を返す。
+func TestMeasurementInfo_ReflectsWindow(t *testing.T) {
+	m := Measurement{
+		Voltages:     make([][]float32, 64),
+		SamplingRate: 10000,
+		Gain:         2000,
+		Start:        30,
+		End:          60,
+	}
+	info := m.Info(450, DtypeInt16)
+
+	if got := info.DurationSec(); got != 30 {
+		t.Errorf("DurationSec()=%v, want 30 (= End-Start, 窓の長さ)", got)
+	}
+	if info.SamplingRate != 10000 || info.Gain != 2000 {
+		t.Errorf("sr=%d gain=%d", info.SamplingRate, info.Gain)
+	}
+	if info.ElectrodeDistance != 450 || !info.HasDistance {
+		t.Errorf("distance=%d hasDistance=%v", info.ElectrodeDistance, info.HasDistance)
+	}
+	if info.Dtype != "int16" {
+		t.Errorf("dtype=%q, want int16", info.Dtype)
+	}
+}
+
+// 電極間距離が 0 (未指定) のとき HasDistance は false。
+func TestMeasurementInfo_NoDistance(t *testing.T) {
+	info := Measurement{}.Info(0, DtypeFloat32)
+	if info.HasDistance {
+		t.Errorf("distance=0 のとき HasDistance は false であるべき")
+	}
+}

--- a/tools/mea2npz/internal/infrastructure/hedbio/reader.go
+++ b/tools/mea2npz/internal/infrastructure/hedbio/reader.go
@@ -71,29 +71,6 @@ func (r *Reader) decodeHed() (samplingRate, gain int, err error) {
 	return sr, g, nil
 }
 
-// Info は .hed/.bio ペアの計測メタ情報を返す。電位データは読まない。
-func (r *Reader) Info(distance int) (domain.MeasurementInfo, error) {
-	sr, gain, err := r.decodeHed()
-	if err != nil {
-		return domain.MeasurementInfo{}, err
-	}
-	bioPath := bioPathFor(r.hedPath)
-	fi, err := os.Stat(bioPath)
-	if err != nil {
-		return domain.MeasurementInfo{}, &domain.ValidationError{
-			Msg: fmt.Sprintf(".bio が見つかりません: %s", bioPath)}
-	}
-	nFrames := int(fi.Size()) / 2 / dataUnitLength
-	return domain.MeasurementInfo{
-		SamplingRate:      sr,
-		Gain:              gain,
-		Start:             0,
-		End:               float64(nFrames) / float64(sr),
-		ElectrodeDistance: distance,
-		HasDistance:       distance > 0,
-	}, nil
-}
-
 // Load は指定時間窓の計測データを読み込む。
 func (r *Reader) Load(w domain.TimeWindow) (domain.Measurement, error) {
 	sr, gain, err := r.decodeHed()

--- a/tools/mea2npz/internal/interface/cli/cli.go
+++ b/tools/mea2npz/internal/interface/cli/cli.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Version はビルド時に -ldflags で差し替え可能。
-var Version = "0.1.0"
+var Version = "1.0.0"
 
 // options は1回の変換実行に必要な設定。フラグ経路と対話経路の両方がこれを組み立てる。
 type options struct {
@@ -91,8 +91,8 @@ func Run(args []string) int {
 	}
 
 	return dispatch(options{
-		input:     fl.Arg(0),
-		out:       *out,
+		input:     unquotePath(fl.Arg(0)),
+		out:       unquotePath(*out),
 		window:    window,
 		dtype:     dtype,
 		distance:  *distance,
@@ -100,6 +100,20 @@ func Run(args []string) int {
 		recursive: *recursive,
 		jobs:      *jobs,
 	})
+}
+
+// unquotePath は Finder やエクスプローラからコピー&ペーストした際に付く
+// 引用符を取り除く。両端が同じ引用符 (' または ") で囲まれている場合のみ外す。
+// 例: '/Volumes/Extreme SSD/data/230411' → /Volumes/Extreme SSD/data/230411
+func unquotePath(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 {
+		q := s[0]
+		if (q == '\'' || q == '"') && s[len(s)-1] == q {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
 }
 
 // dispatch は入力の種別で振り分ける。
@@ -126,21 +140,19 @@ func runSingle(o options) int {
 		return 2
 	}
 
-	reader := hedbio.NewReader(o.input)
-	if info, err := reader.Info(o.distance); err == nil {
-		printInfoTable(os.Stdout, o.input, info, isTerminal(os.Stdout))
-	}
-
 	outPath := resolveSingleOutput(o.input, o.out)
 
 	conv := usecase.NewConvert(
-		reader,
+		hedbio.NewReader(o.input),
 		npz.NewWriter(outPath, o.dtype, o.distance, o.resetTime, o.input),
 	)
-	if err := conv.Execute(o.window); err != nil {
+	m, err := conv.Execute(o.window)
+	if err != nil {
 		fmt.Fprintln(os.Stderr, "エラー:", err)
 		return 1
 	}
+	// 実際に保存した区間の情報を表示する(.npz の情報表示と一致する)。
+	printInfoTable(os.Stdout, o.input, m.Info(o.distance, o.dtype), isTerminal(os.Stdout))
 	fmt.Println("変換完了:", outPath)
 	return 0
 }

--- a/tools/mea2npz/internal/interface/cli/cli_test.go
+++ b/tools/mea2npz/internal/interface/cli/cli_test.go
@@ -1,0 +1,29 @@
+package cli
+
+import "testing"
+
+func TestUnquotePath(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"シングルクォート(Finder)", "'/Volumes/Extreme SSD/研究データ/230411'", "/Volumes/Extreme SSD/研究データ/230411"},
+		{"ダブルクォート(Windows)", `"C:\Users\me\data 230411"`, `C:\Users\me\data 230411`},
+		{"引用符なし", "/home/me/data.hed", "/home/me/data.hed"},
+		{"前後の空白を除去", "  /home/me/data.hed  ", "/home/me/data.hed"},
+		{"クォート+前後空白", "  '/home/me/data.hed'  ", "/home/me/data.hed"},
+		{"両端が不一致なら外さない", `'/home/me/data.hed"`, `'/home/me/data.hed"`},
+		{"片側だけのクォートは外さない", "'/home/me/data.hed", "'/home/me/data.hed"},
+		{"空文字", "", ""},
+		{"クォート1文字のみ", "'", "'"},
+		{"空のクォート", "''", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := unquotePath(c.in); got != c.want {
+				t.Errorf("unquotePath(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/tools/mea2npz/internal/interface/cli/inspect.go
+++ b/tools/mea2npz/internal/interface/cli/inspect.go
@@ -33,7 +33,7 @@ func printInfoTable(w io.Writer, path string, info domain.MeasurementInfo, color
 		{"電極間距離 (um)", dist},
 		{"サンプリングレート (Hz)", strconv.Itoa(info.SamplingRate)},
 		{"GAIN", strconv.Itoa(info.Gain)},
-		{"計測時間 (s)", strconv.FormatFloat(info.DurationSec(), 'g', -1, 64)},
+		{"データ長 (s)", strconv.FormatFloat(info.DurationSec(), 'g', -1, 64)},
 	}
 	if info.Dtype != "" {
 		rows = append(rows, [2]string{"dtype", info.Dtype})

--- a/tools/mea2npz/internal/interface/cli/inspect_test.go
+++ b/tools/mea2npz/internal/interface/cli/inspect_test.go
@@ -24,7 +24,7 @@ func TestPrintInfoTable_ContainsFields(t *testing.T) {
 		"電極間距離 (um)", "450",
 		"サンプリングレート (Hz)", "5000",
 		"GAIN", "50000",
-		"計測時間 (s)", "30",
+		"データ長 (s)", "30",
 		"int16",
 	} {
 		if !strings.Contains(out, want) {

--- a/tools/mea2npz/internal/interface/cli/interactive.go
+++ b/tools/mea2npz/internal/interface/cli/interactive.go
@@ -32,6 +32,7 @@ func collectOptions(in io.Reader, out io.Writer) (options, int, bool) {
 		fmt.Fprintln(out, "入力がありませんでした。終了します。")
 		return options{}, 2, false
 	}
+	input = unquotePath(input)
 	info, err := os.Stat(input)
 	if err != nil {
 		fmt.Fprintln(out, "エラー: 入力が見つかりません:", input)
@@ -72,7 +73,7 @@ func collectOptions(in io.Reader, out io.Writer) (options, int, bool) {
 
 	distance := promptInt(r, out, "電極間距離 (μm)", 450)
 	resetTime := promptYesNo(r, out, "時刻を 0s にリセットする", true)
-	outPath := promptDefault(r, out, "出力先 — 空で既定", "")
+	outPath := unquotePath(promptDefault(r, out, "出力先 — 空で既定", ""))
 
 	recursive := false
 	if info.IsDir() {

--- a/tools/mea2npz/internal/interface/cli/interactive_test.go
+++ b/tools/mea2npz/internal/interface/cli/interactive_test.go
@@ -136,6 +136,26 @@ func TestCollectOptions_DirAsksRecursive(t *testing.T) {
 	}
 }
 
+// Finder からコピーした引用符付きパスでも入力として認識される。
+func TestCollectOptions_QuotedInput(t *testing.T) {
+	hed := tempHed(t)
+	in := script(
+		"'"+hed+"'", // 引用符で囲まれた入力
+		"",          // dtype
+		"n",         // 時間指定なし
+		"",          // 距離
+		"",          // リセット
+		"",          // 出力
+	)
+	o, code, ok := collectOptions(strings.NewReader(in), &bytes.Buffer{})
+	if !ok {
+		t.Fatalf("引用符付き入力で失敗 code=%d", code)
+	}
+	if o.input != hed {
+		t.Errorf("input=%q, want %q", o.input, hed)
+	}
+}
+
 func TestCollectOptions_MissingInput(t *testing.T) {
 	_, code, ok := collectOptions(strings.NewReader("/no/such/path.hed\n"), &bytes.Buffer{})
 	if ok || code != 2 {

--- a/tools/mea2npz/internal/usecase/batch.go
+++ b/tools/mea2npz/internal/usecase/batch.go
@@ -81,7 +81,7 @@ func (b *BatchConvertUseCase) convertOne(input string) {
 		b.report(input, err)
 		return
 	}
-	if err := conv.Execute(b.window); err != nil {
+	if _, err := conv.Execute(b.window); err != nil {
 		b.report(input, err)
 		return
 	}

--- a/tools/mea2npz/internal/usecase/convert.go
+++ b/tools/mea2npz/internal/usecase/convert.go
@@ -14,11 +14,14 @@ func NewConvert(reader domain.MeasurementReader, writer domain.MeasurementWriter
 	return &ConvertUseCase{reader: reader, writer: writer}
 }
 
-// Execute は時間窓を読み込み、保存する。
-func (c *ConvertUseCase) Execute(window domain.TimeWindow) error {
+// Execute は時間窓を読み込み、保存する。保存した計測データを返す(表示・検証用)。
+func (c *ConvertUseCase) Execute(window domain.TimeWindow) (domain.Measurement, error) {
 	m, err := c.reader.Load(window)
 	if err != nil {
-		return err
+		return domain.Measurement{}, err
 	}
-	return c.writer.Write(m)
+	if err := c.writer.Write(m); err != nil {
+		return domain.Measurement{}, err
+	}
+	return m, nil
 }


### PR DESCRIPTION
## 概要

mea2npz を製品版 (v1.0.0) として運用するための改善。CLI の使い勝手と情報表示の意味的な整合性を整えた。

## 変更内容

### 1. パスの引用符を自動で外す
Finder(macOS)やエクスプローラ(Windows)からパスをコピペすると、空白を含むパスが `'...'` / `"..."` で囲まれて渡されることがある。両端が同じ引用符で囲まれている場合のみ除去する `unquotePath` を追加し、CLI 引数・対話モードの入力/出力パス両方に適用した。

例: `'/Volumes/Extreme SSD/研究データ/230411'` → `/Volumes/Extreme SSD/研究データ/230411`

### 2. 変換時の情報表示を実データと一致させる
従来は変換**前**にファイル全体の情報を表示していたため、`start`/`end` で区間を指定すると表示される時間がファイル全体の長さになり、生成された `.npz` の情報表示(区間の長さ)と食い違っていた。

`ConvertUseCase.Execute` が保存した `Measurement` を返すようにし、変換**後**に実際に保存した区間から情報を導出して表示するよう変更。これにより `.npz` の情報表示と必ず一致する。

### 3. ラベル変更:「計測時間」→「データ長」
`End - Start` の値が「元データ全体の長さ」に聞こえる、という指摘を受け、保存されている区間の長さであることが伝わる「データ長 (s)」に変更した。

### その他
- 不要になった `hedbio.Reader.Info` を削除(デッドコード除去)
- バージョンを `1.0.0` に更新

## テスト
- `unquotePath` の単体テスト(引用符あり/なし/不一致/空白付き等)
- 引用符付きパスを対話モードで受理する回帰テスト
- `Measurement.Info` が窓を反映したデータ長を返す単体テスト
- 既存テストのラベル更新

`go build` / `go vet` / `gofmt` / `go test ./...` すべて green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)