### PR TITLE
ci(mea2npz): リリースに linux/arm64 バイナリを追加

### DIFF
--- a/.github/workflows/release-mea2npz.yml
+++ b/.github/workflows/release-mea2npz.yml
@@ -19,6 +19,7 @@ jobs:
           - { goos: darwin, goarch: arm64, ext: "" }
           - { goos: darwin, goarch: amd64, ext: "" }
           - { goos: linux, goarch: amd64, ext: "" }
+          - { goos: linux, goarch: arm64, ext: "" }
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## 概要
mea2npz のリリースワークフローのビルドマトリクスに `linux/arm64` が無く、arm64 環境(Apple Silicon の devcontainer 等)で `install.sh` が GitHub Releases から `mea2npz-linux-arm64` を取得できず **404** になっていた。クロスビルド対象に1行追加して解消する。

## 変更
- `.github/workflows/release-mea2npz.yml` のマトリクスに `{ goos: linux, goarch: arm64 }` を追加

## 反映に必要なこと
このワークフロー修正は**新しいタグ(`mea2npz-vX.Y.Z`)を push して再リリース**したときに有効になります。既存リリースには arm64 は並びません。

## 動作確認
- `CGO_ENABLED=0` のクロスビルド対象であり追加コストはほぼゼロ
- 既存の linux/amd64・darwin・windows と同一フォーマットの1行追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)