### PR TITLE
feat(mea2npz): CLI のログ出力を初心者向けにリッチ化

### DIFF
--- a/tools/mea2npz/internal/interface/cli/cli.go
+++ b/tools/mea2npz/internal/interface/cli/cli.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/kkito0726/MEA_modules/tools/mea2npz/internal/domain"
 	"github.com/kkito0726/MEA_modules/tools/mea2npz/internal/infrastructure/fs"
@@ -35,7 +36,7 @@ type options struct {
 // 引数なしで呼ばれた場合は対話モードに入る。
 func Run(args []string) int {
 	if len(args) == 0 {
-		printBanner(os.Stderr, isTerminal(os.Stderr))
+		printBanner(os.Stderr, colorEnabled(os.Stderr))
 		return runInteractive(os.Stdin, os.Stderr)
 	}
 
@@ -65,7 +66,7 @@ func Run(args []string) int {
 		return 0
 	}
 
-	printBanner(os.Stderr, isTerminal(os.Stderr))
+	printBanner(os.Stderr, colorEnabled(os.Stderr))
 
 	if fl.NArg() != 1 {
 		fmt.Fprintln(os.Stderr, "エラー: 入力 (.hed ファイル or ディレクトリ) を1つ指定してください")
@@ -121,7 +122,7 @@ func unquotePath(s string) string {
 func dispatch(o options) int {
 	info, err := os.Stat(o.input)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "エラー: 入力が見つかりません:", o.input)
+		reportError(os.Stderr, fmt.Errorf("入力が見つかりません: %s", o.input))
 		return 2
 	}
 	if info.IsDir() {
@@ -141,19 +142,26 @@ func runSingle(o options) int {
 	}
 
 	outPath := resolveSingleOutput(o.input, o.out)
+	st := newStyler(colorEnabled(os.Stdout))
+
+	// 大きいファイルは読込・保存に時間がかかるため、開始を明示して利用者を安心させる。
+	fmt.Printf("%s 変換開始\n", st.cyan("▶"))
+	fmt.Printf("   入力: %s\n", o.input)
+	fmt.Printf("   出力: %s\n", outPath)
 
 	conv := usecase.NewConvert(
 		hedbio.NewReader(o.input),
 		npz.NewWriter(outPath, o.dtype, o.distance, o.resetTime, o.input),
 	)
+	start := time.Now()
 	m, err := conv.Execute(o.window)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "エラー:", err)
+		reportError(os.Stderr, err)
 		return 1
 	}
+	fmt.Printf("\n%s 変換完了  %s\n", st.green("✓"), st.dim(fmtDur(time.Since(start))))
 	// 実際に保存した区間の情報を表示する(.npz の情報表示と一致する)。
-	printInfoTable(os.Stdout, o.input, m.Info(o.distance, o.dtype), isTerminal(os.Stdout))
-	fmt.Println("変換完了:", outPath)
+	printInfoTable(os.Stdout, o.input, m.Info(o.distance, o.dtype), colorEnabled(os.Stdout))
 	return 0
 }
 
@@ -165,7 +173,7 @@ func runBatch(o options) int {
 	}
 
 	lister := fs.NewLister()
-	reporter := newConsoleReporter()
+	reporter := newConsoleReporter(colorEnabled(os.Stderr))
 
 	build := func(input, output string) (*usecase.ConvertUseCase, error) {
 		return usecase.NewConvert(
@@ -183,13 +191,14 @@ func runBatch(o options) int {
 	}
 
 	batch := usecase.NewBatch(lister, reporter, build, outputFor, o.window, o.jobs)
+	start := time.Now()
 	if err := batch.Execute(o.input, o.recursive); err != nil {
-		fmt.Fprintln(os.Stderr, "エラー:", err)
+		reportError(os.Stderr, err)
 		return 1
 	}
 
 	ok, skipped, failed := reporter.Summary()
-	fmt.Printf("\n完了: 成功 %d / スキップ %d / 失敗 %d (出力先: %s)\n", ok, skipped, failed, outRoot)
+	printSummary(os.Stdout, newStyler(colorEnabled(os.Stdout)), ok, skipped, failed, time.Since(start), outRoot)
 	if skipped+failed > 0 {
 		return 1
 	}

--- a/tools/mea2npz/internal/interface/cli/cli.go
+++ b/tools/mea2npz/internal/interface/cli/cli.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Version はビルド時に -ldflags で差し替え可能。
-var Version = "1.0.0"
+var Version = "1.1.0"
 
 // options は1回の変換実行に必要な設定。フラグ経路と対話経路の両方がこれを組み立てる。
 type options struct {

--- a/tools/mea2npz/internal/interface/cli/inspect.go
+++ b/tools/mea2npz/internal/interface/cli/inspect.go
@@ -16,10 +16,10 @@ import (
 func runInspect(path string) int {
 	info, err := usecase.NewInspect(npz.NewInfoReader(path)).Execute()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "エラー:", err)
+		reportError(os.Stderr, err)
 		return 1
 	}
-	printInfoTable(os.Stdout, path, info, isTerminal(os.Stdout))
+	printInfoTable(os.Stdout, path, info, colorEnabled(os.Stdout))
 	return 0
 }
 

--- a/tools/mea2npz/internal/interface/cli/messages.go
+++ b/tools/mea2npz/internal/interface/cli/messages.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+// hintFor はエラー文言から初心者向けの対処ヒントを返す(該当なしは空文字)。
+// ドメインのエラー型に依存せず、利用者向けの案内はプレゼンテーション層で持つ(文言マッチの best-effort)。
+func hintFor(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "入力が見つかりません"):
+		return "パスのつづりが正しいか、ファイル/フォルダが存在するか確認してください"
+	case strings.Contains(msg, ".bio が見つかりません"):
+		return ".hed と同じフォルダに「<ファイル名>0001.bio」があるか確認してください"
+	case strings.Contains(msg, ".hed を読み込めません"), strings.Contains(msg, ".hed が短すぎます"):
+		return ".hed ファイルが壊れていないか、正しい計測ファイルか確認してください"
+	case strings.Contains(msg, "未知のGAIN"), strings.Contains(msg, "未知のサンプリングレート"):
+		return "この .hed は対応外の設定です。別の計測ファイルで試してください"
+	case strings.Contains(msg, "データ長を超えています"), strings.Contains(msg, "読み込む区間が空です"):
+		return "-start / -end の秒数がデータ長の範囲内か確認してください"
+	case strings.Contains(msg, "がありません(非対応の形式)"):
+		return "pyMEA で保存した .npz か確認してください"
+	case strings.Contains(msg, "dtype は"):
+		return "-dtype には int16 か float32 を指定してください"
+	}
+	return ""
+}
+
+// reportError はエラーを赤字で表示し、対処ヒントがあれば添える。
+func reportError(f *os.File, err error) {
+	st := newStyler(colorEnabled(f))
+	fmt.Fprintln(f, st.red("✗ エラー:"), err)
+	if h := hintFor(err); h != "" {
+		fmt.Fprintf(f, "   %s %s\n", st.dim("↳ ヒント:"), h)
+	}
+}
+
+// printSummary は一括変換の結果を枠付きで表示する(成功=緑/スキップ=黄/失敗=赤)。
+func printSummary(w io.Writer, st styler, ok, skipped, failed int, elapsed time.Duration, outRoot string) {
+	line := strings.Repeat("─", 48)
+	fmt.Fprintf(w, "\n%s\n", line)
+	fmt.Fprintf(w, "  %s    %s    %s    %s\n",
+		st.green(fmt.Sprintf("成功 %d", ok)),
+		st.yellow(fmt.Sprintf("スキップ %d", skipped)),
+		st.red(fmt.Sprintf("失敗 %d", failed)),
+		st.dim("所要 "+fmtDur(elapsed)),
+	)
+	fmt.Fprintf(w, "  出力先: %s\n", outRoot)
+	fmt.Fprintf(w, "%s\n", line)
+}
+
+// fmtDur は所要時間を読みやすい表記にする(1秒未満は ms、それ以上は秒)。
+func fmtDur(d time.Duration) string {
+	if d < time.Second {
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	}
+	return fmt.Sprintf("%.1fs", d.Seconds())
+}

--- a/tools/mea2npz/internal/interface/cli/reporter.go
+++ b/tools/mea2npz/internal/interface/cli/reporter.go
@@ -3,15 +3,19 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/kkito0726/MEA_modules/tools/mea2npz/internal/usecase"
 )
 
 // consoleReporter は usecase.ProgressReporter を標準エラー出力で実装する。
-// 並列ジョブから呼ばれるためカウントを mutex で保護する。
+// 並列ジョブから呼ばれるためカウントを mutex で保護する。色付け・進捗カウンタ・所要時間を表示する。
 type consoleReporter struct {
 	mu      sync.Mutex
+	st      styler
+	total   int
 	ok      int
 	skipped int
 	failed  int
@@ -20,27 +24,52 @@ type consoleReporter struct {
 // コンパイル時に調停ポートの実装を強制する。
 var _ usecase.ProgressReporter = (*consoleReporter)(nil)
 
-func newConsoleReporter() *consoleReporter { return &consoleReporter{} }
+func newConsoleReporter(color bool) *consoleReporter {
+	return &consoleReporter{st: newStyler(color)}
+}
 
-func (r *consoleReporter) Done(path string) {
+// Begin は並列処理開始前に1回だけ呼ばれる(まだ goroutine は走っていない)。
+func (r *consoleReporter) Begin(total int) {
+	r.total = total
+	fmt.Fprintf(os.Stderr, "%s 全 %d 件を変換します\n\n", r.st.cyan("▶"), total)
+}
+
+// counter は "[n/総数]" を淡色で返す(進捗の見える化)。
+func (r *consoleReporter) counter(n int) string {
+	return r.st.dim(fmt.Sprintf("[%d/%d]", n, r.total))
+}
+
+func (r *consoleReporter) Done(path string, elapsed time.Duration) {
 	r.mu.Lock()
 	r.ok++
+	n := r.ok + r.skipped + r.failed
 	r.mu.Unlock()
-	fmt.Fprintln(os.Stderr, "[OK]  ", path)
+	fmt.Fprintf(os.Stderr, "  %s %s %s  %s\n",
+		r.st.green("✓"), r.counter(n), filepath.Base(path), r.st.dim(fmtDur(elapsed)))
 }
 
 func (r *consoleReporter) Skipped(path string, reason error) {
 	r.mu.Lock()
 	r.skipped++
+	n := r.ok + r.skipped + r.failed
 	r.mu.Unlock()
-	fmt.Fprintln(os.Stderr, "[SKIP]", path, "-", reason)
+	fmt.Fprintf(os.Stderr, "  %s %s %s — %s\n",
+		r.st.yellow("⚠"), r.counter(n), filepath.Base(path), reason)
+	if h := hintFor(reason); h != "" {
+		fmt.Fprintf(os.Stderr, "     %s %s\n", r.st.dim("↳ ヒント:"), h)
+	}
 }
 
 func (r *consoleReporter) Failed(path string, err error) {
 	r.mu.Lock()
 	r.failed++
+	n := r.ok + r.skipped + r.failed
 	r.mu.Unlock()
-	fmt.Fprintln(os.Stderr, "[FAIL]", path, "-", err)
+	fmt.Fprintf(os.Stderr, "  %s %s %s — %s\n",
+		r.st.red("✗"), r.counter(n), filepath.Base(path), err)
+	if h := hintFor(err); h != "" {
+		fmt.Fprintf(os.Stderr, "     %s %s\n", r.st.dim("↳ ヒント:"), h)
+	}
 }
 
 func (r *consoleReporter) Summary() (ok, skipped, failed int) {

--- a/tools/mea2npz/internal/interface/cli/style.go
+++ b/tools/mea2npz/internal/interface/cli/style.go
@@ -1,0 +1,41 @@
+package cli
+
+import "os"
+
+// ANSI エスケープシーケンス。端末以外・NO_COLOR 設定時は使わない(no-color.org 慣習)。
+const (
+	ansiReset  = "\033[0m"
+	ansiDim    = "\033[2m"
+	ansiRed    = "\033[31m"
+	ansiGreen  = "\033[32m"
+	ansiYellow = "\033[33m"
+	ansiCyan   = "\033[36m"
+)
+
+// colorEnabled は f が端末で、かつ NO_COLOR が未設定(空文字含む)のとき true。
+// パイプ・リダイレクト・NO_COLOR 環境では装飾を行わずプレーン出力にする。
+func colorEnabled(f *os.File) bool {
+	if v := os.Getenv("NO_COLOR"); v != "" {
+		return false
+	}
+	return isTerminal(f)
+}
+
+// styler は色付けの有無を保持し、条件付きで ANSI 装飾するヘルパ。
+// on=false のときは素通し(同じ呼び出しでプレーン出力になる)。
+type styler struct{ on bool }
+
+func newStyler(on bool) styler { return styler{on: on} }
+
+func (s styler) wrap(code, text string) string {
+	if !s.on {
+		return text
+	}
+	return code + text + ansiReset
+}
+
+func (s styler) green(t string) string  { return s.wrap(ansiGreen, t) }
+func (s styler) yellow(t string) string { return s.wrap(ansiYellow, t) }
+func (s styler) red(t string) string    { return s.wrap(ansiRed, t) }
+func (s styler) cyan(t string) string   { return s.wrap(ansiCyan, t) }
+func (s styler) dim(t string) string    { return s.wrap(ansiDim, t) }

--- a/tools/mea2npz/internal/usecase/batch.go
+++ b/tools/mea2npz/internal/usecase/batch.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/kkito0726/MEA_modules/tools/mea2npz/internal/domain"
 )
@@ -53,6 +54,9 @@ func (b *BatchConvertUseCase) Execute(root string, recursive bool) error {
 		return err
 	}
 
+	// 並列処理に入る前に総数を通知し、利用者へ「これから N 件処理する」と伝える。
+	b.reporter.Begin(len(files))
+
 	sem := make(chan struct{}, b.jobs)
 	var wg sync.WaitGroup
 	for _, input := range files {
@@ -81,11 +85,12 @@ func (b *BatchConvertUseCase) convertOne(input string) {
 		b.report(input, err)
 		return
 	}
+	start := time.Now()
 	if _, err := conv.Execute(b.window); err != nil {
 		b.report(input, err)
 		return
 	}
-	b.reporter.Done(input)
+	b.reporter.Done(input, time.Since(start))
 }
 
 func (b *BatchConvertUseCase) report(input string, err error) {

--- a/tools/mea2npz/internal/usecase/batch_test.go
+++ b/tools/mea2npz/internal/usecase/batch_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/kkito0726/MEA_modules/tools/mea2npz/internal/domain"
 )
@@ -17,9 +18,10 @@ type fakeReporter struct {
 	ok, skipped, failed int
 }
 
-func (r *fakeReporter) Done(string)           { r.mu.Lock(); r.ok++; r.mu.Unlock() }
-func (r *fakeReporter) Skipped(string, error) { r.mu.Lock(); r.skipped++; r.mu.Unlock() }
-func (r *fakeReporter) Failed(string, error)  { r.mu.Lock(); r.failed++; r.mu.Unlock() }
+func (r *fakeReporter) Begin(int)                  {}
+func (r *fakeReporter) Done(string, time.Duration) { r.mu.Lock(); r.ok++; r.mu.Unlock() }
+func (r *fakeReporter) Skipped(string, error)      { r.mu.Lock(); r.skipped++; r.mu.Unlock() }
+func (r *fakeReporter) Failed(string, error)       { r.mu.Lock(); r.failed++; r.mu.Unlock() }
 func (r *fakeReporter) Summary() (int, int, int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/tools/mea2npz/internal/usecase/ports.go
+++ b/tools/mea2npz/internal/usecase/ports.go
@@ -2,6 +2,8 @@
 // データ読込/書込のポートは domain 側(リポジトリポート)に置く。
 package usecase
 
+import "time"
+
 // FileLister はディレクトリから変換対象を列挙する調停ポート。
 type FileLister interface {
 	List(root string, recursive bool) ([]string, error)
@@ -9,8 +11,9 @@ type FileLister interface {
 
 // ProgressReporter は一括変換の進捗・サマリを通知する調停ポート。
 type ProgressReporter interface {
-	Done(path string)                  // 変換成功
-	Skipped(path string, reason error) // バリデーション等でスキップ(処理は継続)
-	Failed(path string, err error)     // 実行時エラーでスキップ(処理は継続)
+	Begin(total int)                         // 変換対象の総数(処理開始時に1回)
+	Done(path string, elapsed time.Duration) // 変換成功(所要時間付き)
+	Skipped(path string, reason error)       // バリデーション等でスキップ(処理は継続)
+	Failed(path string, err error)           // 実行時エラーでスキップ(処理は継続)
 	Summary() (ok, skipped, failed int)
 }


### PR DESCRIPTION
## 概要
mea2npz CLI のログ出力を分かりやすくし、初心者でも使いやすくする。外部依存は増やさず**標準ライブラリ + ANSI のみ**で実装。非端末・`NO_COLOR` 時は自動でプレーン出力に切り替わる。

## 変更点
- **変換開始ログ**: 単一は「▶ 変換開始(入力/出力)」、一括は「▶ 全 N 件を変換します」を処理前に表示し、待ち時間の不安を解消
- **色付き記号**: `✓`緑 / `⚠`黄 / `✗`赤 / `▶`cyan で状態を一目化
- **進捗カウンタ**: 一括変換の各行に `[n/総数]` を表示
- **所要時間**: 各変換と全体の処理時間を表示(`time.Since`)
- **サマリ枠**: 成功/スキップ/失敗を罫線枠で色分け表示
- **エラーヒント**: 失敗時に「↳ ヒント:」で対処を案内(.bio欠如・GAIN未知・区間超過・非対応npz・dtype・パス誤り)
- **NO_COLOR 対応**: [no-color.org](https://no-color.org) 慣習に従い、非端末・`NO_COLOR` 設定時は装飾オフ

## 出力イメージ(プレーン)
\`\`\`
▶ 全 3 件を変換します

  ✓ [1/3] 1102_dish3_..._.hed  90ms
  ✓ [2/3] 230615_day2_..._.hed  99ms
  ✓ [3/3] 230627_day3_..._.hed  118ms

────────────────────────────────────────────────
  成功 3    スキップ 0    失敗 0    所要 122ms
  出力先: /tmp/b
────────────────────────────────────────────────
\`\`\`

## 設計
- `ProgressReporter` に `Begin(total)` と `Done(path, elapsed)` を追加。`var _ ProgressReporter` のコンパイル時アサーションとテスト mock も合わせて更新
- 色判定を `colorEnabled`(端末判定 + `NO_COLOR`)に集約。stdout/stderr で別々に判定するため片方だけリダイレクトしても正しく装飾オフ
- 利用者向けヒントはプレゼンテーション層(`messages.go: hintFor`)に隔離し、ドメインのエラー型に依存しない

## 動作確認
- `go build` / `go vet` / `gofmt -l`(差分なし)/ `go test` 全てグリーン
- 実データ3ファイルで色付き(擬似端末)・プレーン(パイプ/NO_COLOR)・各エラーヒントを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)