### PR TITLE
ci: Marpスライドを GitHub Pages で公開（選択トップページ付き）

### DIFF
--- a/.github/workflows/deploy-slides.yml
+++ b/.github/workflows/deploy-slides.yml
@@ -67,8 +67,10 @@ jobs:
               transition:transform .12s ease, box-shadow .12s ease, border-color .12s ease;
             }
             .card:hover{ transform:translateY(-3px); box-shadow:0 12px 28px rgba(15,30,60,.12); border-left-color:var(--accent); }
-            .card .t{ font-size:21px; font-weight:700; }
-            .card .f{ font-family:'JetBrains Mono',monospace; font-size:13px; color:var(--mute); margin-top:4px; }
+            .meta{ flex:1; padding-right:18px; }
+            .card .t{ display:block; font-size:21px; font-weight:700; }
+            .card .d{ display:block; margin-top:7px; font-size:14px; line-height:1.6; color:var(--fg); }
+            .card .f{ display:block; margin-top:7px; font-family:'JetBrains Mono',monospace; font-size:12px; color:var(--mute); }
             .card .go{ font-family:'JetBrains Mono',monospace; color:var(--primary); font-weight:800; font-size:22px; }
             footer{ margin-top:40px; color:var(--mute); font-size:13px; font-family:'JetBrains Mono',monospace; }
           </style>
@@ -80,18 +82,36 @@ jobs:
           <div class="grid">
           HTML
 
-          # 各スライドを HTML 化し、トップページにリンクを追加
-          for f in $(find docs -name '*_slides.md' | sort); do
+          # スライドを HTML 化し、トップページにカード（タイトル＋説明）を追加する関数
+          emit_card () {
+            f="$1"; desc="$2"
             base=$(basename "$f" .md)
             title=$(grep -m1 '^# ' "$f" | sed -e 's/^# //' -e 's/<[^>]*>//g')
             echo "Building $f -> site/${base}.html (${title})"
             npx -y @marp-team/marp-cli@latest "$f" -o "site/${base}.html"
             {
               echo "<a class=\"card\" href=\"./${base}.html\">"
-              echo "  <span><span class=\"t\">${title}</span><br><span class=\"f\">${f}</span></span>"
+              echo "  <span class=\"meta\">"
+              echo "    <span class=\"t\">${title}</span>"
+              echo "    <span class=\"d\">${desc}</span>"
+              echo "    <span class=\"f\">${f}</span>"
+              echo "  </span>"
               echo "  <span class=\"go\">&rarr;</span>"
               echo "</a>"
             } >> site/index.html
+          }
+
+          # 表示順と内容説明（この順でトップページに並ぶ）
+          emit_card "docs/pyMEA_code_guide_slides.md"         "pyMEA で MEA 計測データを解析する基本パターンを初心者向けに解説"
+          emit_card "docs/setup/devcontainer_guide_slides.md" "Dev Container を使って pyMEA の開発・解析環境を手早く構築する手順を解説"
+          emit_card "docs/mea2npz_manual_slides.md"           "複数の .hed/.bio をまとめて .npz に変換する Python 非依存の CLI ツール mea2npz の使い方を解説"
+
+          # 上記リストに無い *_slides.md があれば末尾へ自動追加（説明なし）
+          for f in $(find docs -name '*_slides.md' | sort); do
+            case "$f" in
+              docs/pyMEA_code_guide_slides.md|docs/setup/devcontainer_guide_slides.md|docs/mea2npz_manual_slides.md) ;;
+              *) emit_card "$f" "" ;;
+            esac
           done
 
           # フッター

--- a/.github/workflows/deploy-slides.yml
+++ b/.github/workflows/deploy-slides.yml
@@ -1,0 +1,118 @@
+name: Deploy Slides to Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**/*_slides.md'
+      - '.github/workflows/deploy-slides.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build slide decks and index page
+        run: |
+          set -e
+          mkdir -p site
+
+          # トップページ（スライド選択）のヘッダー
+          cat > site/index.html <<'HTML'
+          <!doctype html>
+          <html lang="ja">
+          <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>pyMEA スライド一覧</title>
+          <link rel="preconnect" href="https://fonts.googleapis.com">
+          <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=JetBrains+Mono:wght@500;800&display=swap" rel="stylesheet">
+          <style>
+            :root{ --primary:#2f6df6; --accent:#06b6d4; --fg:#1f2a37; --mute:#5b6b7c; --border:#d8e1ec; }
+            *{ box-sizing:border-box; }
+            body{
+              margin:0; min-height:100vh; color:var(--fg);
+              font-family:'Noto Sans JP',sans-serif;
+              background:#f4f7fb;
+              background-image:
+                radial-gradient(circle at 0% 0%, rgba(47,109,246,.08), transparent 40%),
+                radial-gradient(circle at 100% 100%, rgba(6,182,212,.08), transparent 40%);
+              padding:64px 24px;
+            }
+            .wrap{ max-width:880px; margin:0 auto; }
+            h1{
+              font-family:'JetBrains Mono',monospace; font-weight:800;
+              color:var(--primary); font-size:40px; margin:0 0 6px;
+            }
+            h1::before{ content:'# '; color:var(--accent); }
+            .lead{ color:var(--mute); margin:0 0 36px; font-size:17px; }
+            .grid{ display:grid; gap:18px; }
+            .card{
+              display:flex; align-items:center; justify-content:space-between;
+              text-decoration:none; color:inherit; background:#fff;
+              border:1px solid var(--border); border-left:5px solid var(--primary);
+              border-radius:12px; padding:22px 26px;
+              box-shadow:0 6px 20px rgba(15,30,60,.06);
+              transition:transform .12s ease, box-shadow .12s ease, border-color .12s ease;
+            }
+            .card:hover{ transform:translateY(-3px); box-shadow:0 12px 28px rgba(15,30,60,.12); border-left-color:var(--accent); }
+            .card .t{ font-size:21px; font-weight:700; }
+            .card .f{ font-family:'JetBrains Mono',monospace; font-size:13px; color:var(--mute); margin-top:4px; }
+            .card .go{ font-family:'JetBrains Mono',monospace; color:var(--primary); font-weight:800; font-size:22px; }
+            footer{ margin-top:40px; color:var(--mute); font-size:13px; font-family:'JetBrains Mono',monospace; }
+          </style>
+          </head>
+          <body>
+          <div class="wrap">
+          <h1>pyMEA スライド一覧</h1>
+          <p class="lead">見たいスライドを選んでください。ブラウザ上でページ送りして閲覧できます（←→キー）。</p>
+          <div class="grid">
+          HTML
+
+          # 各スライドを HTML 化し、トップページにリンクを追加
+          for f in $(find docs -name '*_slides.md' | sort); do
+            base=$(basename "$f" .md)
+            title=$(grep -m1 '^# ' "$f" | sed -e 's/^# //' -e 's/<[^>]*>//g')
+            echo "Building $f -> site/${base}.html (${title})"
+            npx -y @marp-team/marp-cli@latest "$f" -o "site/${base}.html"
+            {
+              echo "<a class=\"card\" href=\"./${base}.html\">"
+              echo "  <span><span class=\"t\">${title}</span><br><span class=\"f\">${f}</span></span>"
+              echo "  <span class=\"go\">&rarr;</span>"
+              echo "</a>"
+            } >> site/index.html
+          done
+
+          # フッター
+          cat >> site/index.html <<'HTML'
+          </div>
+          <footer>// Generated from docs/**/*_slides.md by GitHub Actions</footer>
+          </div>
+          </body>
+          </html>
+          HTML
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## 概要

`docs/**/*_slides.md` の Marp スライドを GitHub Actions で HTML 化し、**GitHub Pages 上でスライドショーとして閲覧**できるようにします。トップページにどのスライドを見るか選べる一覧（リンク）を自動生成します。

## 仕組み

1. `main` への push（`*_slides.md` 変更時）または手動実行で起動
2. `marp-cli` で各スライドを自己完結 HTML に変換（埋め込み CSS もそのまま反映＝白基調デザイン維持／←→キーでページ送り）
3. 各スライドの H1 をタイトルに、**選択用トップページ `index.html` を自動生成**
4. GitHub Pages へデプロイ

公開URL（予定）: `https://kkito0726.github.io/MEA_modules/`

対象スライド（現状3つ、今後 `*_slides.md` を追加すれば自動で増える）:
- pyMEA コードガイド
- mea2npz
- Dev Container を使った開発環境構築ガイド

## ⚠️ マージ後に必要な1回だけの設定

リポジトリの **Settings → Pages → Build and deployment → Source を「GitHub Actions」** に設定してください（未設定だと deploy ステップが失敗します）。

## テスト
- [x] ワークフロー YAML の妥当性を検証
- [x] run スクリプトをローカル抽出し、3スライドの HTML 化＋トップページ生成までエンドツーエンドで動作確認