### PR TITLE
ci: スライド一覧トップページをスマホ対応

### DIFF
--- a/.github/workflows/deploy-slides.yml
+++ b/.github/workflows/deploy-slides.yml
@@ -67,12 +67,24 @@ jobs:
               transition:transform .12s ease, box-shadow .12s ease, border-color .12s ease;
             }
             .card:hover{ transform:translateY(-3px); box-shadow:0 12px 28px rgba(15,30,60,.12); border-left-color:var(--accent); }
-            .meta{ flex:1; padding-right:18px; }
+            .meta{ flex:1; min-width:0; padding-right:18px; overflow-wrap:break-word; }
             .card .t{ display:block; font-size:21px; font-weight:700; }
             .card .d{ display:block; margin-top:7px; font-size:14px; line-height:1.6; color:var(--fg); }
-            .card .f{ display:block; margin-top:7px; font-family:'JetBrains Mono',monospace; font-size:12px; color:var(--mute); }
-            .card .go{ font-family:'JetBrains Mono',monospace; color:var(--primary); font-weight:800; font-size:22px; }
-            footer{ margin-top:40px; color:var(--mute); font-size:13px; font-family:'JetBrains Mono',monospace; }
+            .card .f{ display:block; margin-top:7px; font-family:'JetBrains Mono',monospace; font-size:12px; color:var(--mute); word-break:break-all; }
+            .card .go{ flex-shrink:0; font-family:'JetBrains Mono',monospace; color:var(--primary); font-weight:800; font-size:22px; }
+            footer{ margin-top:40px; color:var(--mute); font-size:13px; font-family:'JetBrains Mono',monospace; word-break:break-all; }
+            @media (max-width:640px){
+              body{ padding:36px 16px; }
+              h1{ font-size:28px; }
+              .lead{ font-size:14px; margin-bottom:24px; }
+              .grid{ gap:14px; }
+              .card{ padding:18px 18px; border-radius:10px; }
+              .meta{ padding-right:12px; }
+              .card .t{ font-size:17px; }
+              .card .d{ font-size:13px; }
+              .card .f{ font-size:11px; }
+              .card .go{ font-size:18px; }
+            }
           </style>
           </head>
           <body>


### PR DESCRIPTION
## 概要

GitHub Pages のスライド一覧トップページ (`index.html`) を**スマホでもレイアウトが崩れない**ようにレスポンシブ対応しました。

## 変更内容

- `max-width:640px` のメディアクエリを追加し、余白・見出し・カードのフォントサイズをスマホ向けに最適化
- 長いファイルパスやフッターの折り返し（`word-break:break-all`）で横スクロールを防止
- カードの矢印アイコンの潰れ防止（`flex-shrink:0`）と説明領域の `min-width:0`（flex子要素の縮小許可）

## 検証（marp 同梱 puppeteer で実機相当ビューポート）

| 幅 | innerWidth | scrollWidth | 判定 |
|----|-----------|-------------|------|
| 390px (スマホ) | 390 | 390 | ✅ 横はみ出しなし |
| 1200px (PC) | 1200 | 1200 | ✅ 横はみ出しなし |

- スマホ幅でタイトル・説明文が正しく折り返し、矢印・ファイルパスもはみ出さないことをスクリーンショットで確認